### PR TITLE
Fix: Resolve TypeScript errors after translation

### DIFF
--- a/web/src/data/api/WebNovelRepository.ts
+++ b/web/src/data/api/WebNovelRepository.ts
@@ -140,7 +140,7 @@ const createFileUrl = ({
 }: {
   providerId: string;
   novelId: string;
-  mode: 'jp' | 'zh' | 'zh-jp' | 'jp-zh';
+  mode: 'jp' | 'zh' | 'zh-jp' | 'jp-zh' | 'en' | 'en-jp' | 'jp-en';
   translationsMode: 'parallel' | 'priority';
   translations: ('sakura' | 'baidu' | 'youdao' | 'gpt')[];
   type: 'epub' | 'txt';

--- a/web/src/data/api/WenkuNovelRepository.ts
+++ b/web/src/data/api/WenkuNovelRepository.ts
@@ -32,7 +32,7 @@ const getNovel = (novelId: string) =>
 
 interface WenkuNovelCreateBody {
   title: string;
-  titleZh: string;
+  titleEn: string;
   cover?: string;
   authors: string[];
   artists: string[];
@@ -54,7 +54,7 @@ const updateGlossary = (id: string, json: { [key: string]: string }) =>
 const createVolume = (
   novelId: string,
   volumeId: string,
-  type: 'jp' | 'zh',
+  type: 'jp' | 'zh' | 'en',
   file: File,
   onProgress: (p: number) => void,
 ) =>
@@ -115,7 +115,7 @@ const createFileUrl = ({
 }: {
   novelId: string;
   volumeId: string;
-  mode: 'zh' | 'zh-jp' | 'jp-zh';
+  mode: 'zh' | 'zh-jp' | 'jp-zh' | 'en' | 'en-jp' | 'jp-en';
   translationsMode: 'parallel' | 'priority';
   translations: ('sakura' | 'baidu' | 'youdao' | 'gpt')[];
 }) => {

--- a/web/src/data/local/EpubParser.ts
+++ b/web/src/data/local/EpubParser.ts
@@ -2,7 +2,7 @@ interface EpubParser {
   extractText: (doc: Document) => string[];
   injectTranslation: (
     doc: Document,
-    mode: 'zh' | 'jp-zh' | 'zh-jp',
+    mode: 'en' | 'en-jp' | 'jp-en' | 'zh' | 'zh-jp' | 'jp-zh',
     zhLinesList: string[][],
   ) => Document;
 }
@@ -21,13 +21,13 @@ export const EpubParserV1: EpubParser = {
   },
   injectTranslation: (
     doc: Document,
-    mode: 'zh' | 'jp-zh' | 'zh-jp',
+    mode: 'en' | 'en-jp' | 'jp-en' | 'zh' | 'zh-jp' | 'jp-zh',
     zhLinesList: string[][],
   ) => {
     Array.from(doc.body.getElementsByTagName('p'))
       .filter((el) => el.innerText.trim().length !== 0)
       .forEach((el, index) => {
-        if (mode === 'zh') {
+        if (mode === 'zh' || mode === 'en') {
           zhLinesList.forEach((lines) => {
             const p = document.createElement('p');
             const t = document.createTextNode(lines[index]);
@@ -35,7 +35,7 @@ export const EpubParserV1: EpubParser = {
             el.parentNode!.insertBefore(p, el);
           });
           el.parentNode!.removeChild(el);
-        } else if (mode === 'jp-zh') {
+        } else if (mode === 'jp-zh' || mode === 'jp-en') {
           zhLinesList.forEach((lines) => {
             const p = document.createElement('p');
             const t = document.createTextNode(lines[index]);

--- a/web/src/data/local/GetTranslationFile.ts
+++ b/web/src/data/local/GetTranslationFile.ts
@@ -12,7 +12,7 @@ export const getTranslationFile = async (
     translations,
   }: {
     id: string;
-    mode: 'zh' | 'zh-jp' | 'jp-zh';
+    mode: 'en' | 'en-jp' | 'jp-en' | 'zh' | 'zh-jp' | 'jp-zh';
     translationsMode: 'parallel' | 'priority';
     translations: ('sakura' | 'baidu' | 'youdao' | 'gpt')[];
   },
@@ -60,9 +60,9 @@ export const getTranslationFile = async (
         buffer.push('// This segment of translation is missing.');
       } else {
         const combinedLinesList = zhLinesList;
-        if (mode === 'jp-zh') {
+        if (mode === 'jp-zh' || mode === 'jp-en') {
           combinedLinesList.unshift(jpLines);
-        } else if (mode === 'zh-jp') {
+        } else if (mode === 'zh-jp' || mode === 'en-jp') {
           combinedLinesList.push(jpLines);
         }
         for (let i = 0; i < combinedLinesList[0].length; i++) {
@@ -98,9 +98,9 @@ export const getTranslationFile = async (
         texts.push(zhLines.slice(0, s.text.length));
         zhLines.splice(0, s.text.length);
       }
-      if (mode === 'jp-zh') {
+      if (mode === 'jp-zh' || mode === 'jp-en') {
         texts.unshift(s.text);
-      } else if (mode === 'zh-jp') {
+      } else if (mode === 'zh-jp' || mode === 'en-jp') {
         texts.push(s.text);
       }
 

--- a/web/src/pages/list/components/NovelListWenku.vue
+++ b/web/src/pages/list/components/NovelListWenku.vue
@@ -54,7 +54,7 @@ defineExpose({
         <router-link :to="`/wenku/${item.id}`">
           <ImageCard
             :src="item.cover"
-            :title="item.titleZh ? item.titleZh : item.title"
+            :title="item.titleEn ? item.titleEn : item.title"
           >
             <template #prefix>
               <n-text v-if="item.favored" type="warning">

--- a/web/src/pages/novel/WenkuNovelEdit.vue
+++ b/web/src/pages/novel/WenkuNovelEdit.vue
@@ -39,11 +39,11 @@ const allowSubmit = ref(novelId === undefined);
 const formRef = ref<FormInst>();
 const formValue = ref({
   title: '',
-  titleZh: '',
+  titleEn: '',
   cover: '',
   authors: <string[]>[],
   artists: <string[]>[],
-  level: '一般向',
+  level: 'For All Ages',
   keywords: <string[]>[],
   introduction: '',
   volumes: <WenkuVolumeDto[]>[],

--- a/web/src/pages/novel/components/TranslateOptions.vue
+++ b/web/src/pages/novel/components/TranslateOptions.vue
@@ -189,14 +189,14 @@ const showDownloadModal = ref(false);
 
         <c-action-wrapper
           v-if="gnid.type === 'web'"
-          title="中文文件名"
+          title="English Filename"
           align="center"
         >
           <n-switch
             size="small"
-            :value="setting.downloadFilenameType === 'zh'"
+            :value="setting.downloadFilenameType === 'en'"
             @update-value="
-              (it: boolean) => (setting.downloadFilenameType = it ? 'zh' : 'jp')
+              (it: boolean) => (setting.downloadFilenameType = it ? 'en' : 'jp')
             "
           />
         </c-action-wrapper>

--- a/web/src/pages/reader/components/BuildParagraphs.ts
+++ b/web/src/pages/reader/components/BuildParagraphs.ts
@@ -32,7 +32,7 @@ export const buildParagraphs = (
   const needSpeakJp =
     setting.mode === 'jp' || setting.speakLanguages.includes('jp');
   const needSpeakZh =
-    setting.mode === 'zh' || setting.speakLanguages.includes('zh');
+    setting.mode === 'en' || setting.speakLanguages.includes('en');
 
   if (setting.mode === 'jp') {
     styles.push({
@@ -42,7 +42,7 @@ export const buildParagraphs = (
       needSpeak: needSpeakJp,
     });
   } else {
-    if (setting.mode === 'jp-zh') {
+    if (setting.mode === 'jp-en') {
       styles.push({
         paragraphs: chapter.paragraphs,
         source: 'J',
@@ -112,7 +112,7 @@ export const buildParagraphs = (
       }
     }
 
-    if (setting.mode === 'zh-jp') {
+    if (setting.mode === 'en-jp') {
       styles.push({
         paragraphs: chapter.paragraphs,
         source: 'J',

--- a/web/src/pages/reader/components/ReaderContent.vue
+++ b/web/src/pages/reader/components/ReaderContent.vue
@@ -114,7 +114,7 @@ const textUnderlineOffset = computed(() => {
   margin-right: 0.5em;
 }
 #chapter-content p .first {
-  opacity: v-bind('setting.mixZhOpacity');
+  opacity: v-bind('setting.mixEnOpacity');
 }
 #chapter-content p .second {
   opacity: v-bind('setting.mixJpOpacity');

--- a/web/src/pages/reader/components/ReaderSettingModal.vue
+++ b/web/src/pages/reader/components/ReaderSettingModal.vue
@@ -186,9 +186,9 @@ const setCustomFontColor = (color: string) =>
             </n-flex>
           </c-action-wrapper>
 
-          <c-action-wrapper title="主透明度" align="center">
+          <c-action-wrapper title="Main Opacity" align="center">
             <n-slider
-              v-model:value="setting.mixZhOpacity"
+              v-model:value="setting.mixEnOpacity"
               :max="1"
               :min="0"
               :step="0.05"
@@ -198,11 +198,11 @@ const setCustomFontColor = (color: string) =>
               style="flex: auto"
             />
             <n-text style="width: 6em">
-              {{ (setting.mixZhOpacity * 100).toFixed(0) }}%
+              {{ (setting.mixEnOpacity * 100).toFixed(0) }}%
             </n-text>
           </c-action-wrapper>
 
-          <c-action-wrapper title="辅透明度" align="center">
+          <c-action-wrapper title="Secondary Opacity" align="center">
             <n-slider
               v-model:value="setting.mixJpOpacity"
               :max="1"

--- a/web/src/util/UseOpenCC.ts
+++ b/web/src/util/UseOpenCC.ts
@@ -1,4 +1,4 @@
-type Locale = 'zh-cn' | 'zh-tw';
+type Locale = 'zh-cn' | 'zh-tw' | 'en-us';
 
 type Converter = {
   toView: (text: string) => string;
@@ -11,7 +11,7 @@ export const defaultConverter: Converter = {
 };
 
 export async function useOpenCC(locale: Locale) {
-  if (locale === 'zh-cn') {
+  if (locale === 'zh-cn' || locale === 'en-us') {
     return defaultConverter;
   } else if (locale === 'zh-tw') {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This commit fixes a series of TypeScript errors that occurred after translating the application from Chinese to English.

The changes include:
- Updating various type definitions (e.g., for locales and modes) to accept new English-language values.
- Correcting property names in data models and components from their old Chinese-based names to new English ones (e.g., `titleZh` to `titleEn`, `mixZhOpacity` to `mixEnOpacity`).
- Adjusting logic in components and utility functions to handle the new English values and resolve type conflicts.
- Fixing component state initialization to use the correct English-based property names.