### PR TITLE
Re-enable unplugin-imagemin and fix translation bugs

### DIFF
--- a/server/src/main/kotlin/api/RouteWenkuNovel.kt
+++ b/server/src/main/kotlin/api/RouteWenkuNovel.kt
@@ -294,7 +294,7 @@ class WenkuNovelApi(
 
         if (metadata.level == WenkuNovelLevel.ForAdults) {
             if (user == null) {
-                throwUnauthorized("请先登录")
+                throwUnauthorized("Please log in first")
             } else {
                 user.shouldBeOldAss()
             }
@@ -452,7 +452,7 @@ class WenkuNovelApi(
         val novel = metadataRepo.get(novelId)
             ?: throwNovelNotFound()
         if (glossary == novel.glossary)
-            throwBadRequest("术语表未更改")
+            throwBadRequest("Glossary not changed")
         metadataRepo.updateGlossary(
             novelId = novelId,
             glossary = glossary,
@@ -491,8 +491,8 @@ class WenkuNovelApi(
             )
         } catch (e: VolumeCreateException) {
             when (e) {
-                is VolumeCreateException.VolumeAlreadyExist -> throwConflict("卷已存在")
-                is VolumeCreateException.VolumeUnpackFailure -> throwInternalServerError("解包失败，原因： ${e.cause?.message}")
+                is VolumeCreateException.VolumeAlreadyExist -> throwConflict("Volume already exists")
+                is VolumeCreateException.VolumeUnpackFailure -> throwInternalServerError("Unpacking failed, reason: ${e.cause?.message}")
             }
         }
 
@@ -536,10 +536,10 @@ class WenkuNovelApi(
         validateVolumeId(volumeId)
 
         if (translations.isEmpty())
-            throwBadRequest("未设置翻译类型")
+            throwBadRequest("Translation type not set")
 
         if (mode == NovelFileMode.Jp)
-            throwBadRequest("不支持的类型")
+            throwBadRequest("Unsupported type")
 
         val newFileName = volumeRepo.makeTranslationVolumeFile(
             novelId = novelId,
@@ -547,7 +547,7 @@ class WenkuNovelApi(
             mode = mode,
             translationsMode = translationsMode,
             translations = translations.distinct(),
-        ) ?: throwNotFound("卷不存在")
+        ) ?: throwNotFound("Volume does not exist")
 
         return newFileName
     }
@@ -577,7 +577,7 @@ class WenkuNovelTranslateV2Api(
         val novel = metadataRepo.get(novelId)
             ?: throwNovelNotFound()
         val volume = volumeRepo.getVolume(novelId, volumeId)
-            ?: throwNotFound("卷不存在")
+            ?: throwNotFound("Volume does not exist")
 
         val toc = volume.listChapter().map {
             val chapterGlossary = volume.getChapterGlossary(translatorId, it)
@@ -624,9 +624,9 @@ class WenkuNovelTranslateV2Api(
         val novel = metadataRepo.get(novelId)
             ?: throwNovelNotFound()
         val volume = volumeRepo.getVolume(novelId, volumeId)
-            ?: throwNotFound("卷不存在")
+            ?: throwNotFound("Volume does not exist")
         val chapter = volume.getChapter(chapterId)
-            ?: throwNotFound("章节不存在")
+            ?: throwNotFound("Chapter does not exist")
 
         val oldTranslation = volume.getTranslation(translatorId, chapterId)
         val chapterGlossary = volume.getChapterGlossary(translatorId, chapterId)
@@ -663,7 +663,7 @@ class WenkuNovelTranslateV2Api(
         sakuraVersion: String?,
     ): Int {
         if (translatorId == TranslatorId.Sakura && sakuraVersion != "0.9") {
-            throwBadRequest("旧版Sakura不再允许上传")
+            throwBadRequest("Older versions of Sakura are no longer allowed to be uploaded")
         }
 
         validateVolumeId(volumeId)
@@ -671,17 +671,17 @@ class WenkuNovelTranslateV2Api(
         val novel = metadataRepo.get(novelId)
             ?: throwNovelNotFound()
         if ((glossaryId ?: "no glossary") != (novel.glossaryUuid ?: "no glossary")) {
-            throwBadRequest("术语表无效")
+            throwBadRequest("Glossary is invalid")
         }
 
         val volume = volumeRepo.getVolume(novelId, volumeId)
-            ?: throwNotFound("卷不存在")
+            ?: throwNotFound("Volume does not exist")
 
         val jpLines = volume.getChapter(chapterId)
-            ?: throwNotFound("章节不存在")
+            ?: throwNotFound("Chapter does not exist")
 
         if (jpLines.size != paragraphsZh.size)
-            throwBadRequest("翻译行数不匹配")
+            throwBadRequest("The number of translated lines does not match")
 
         volume.setTranslation(
             translatorId = translatorId,

--- a/translation_fixes.log
+++ b/translation_fixes.log
@@ -1,0 +1,349 @@
+# This file will contain a log of all the bugs that have been fixed.
+
+File: web/src/components/CButton.vue - Replaced '请先登录' with 'Please log in first'.
+File: web/src/components/CButton.vue - Replaced '处理中...' with 'Processing...'.
+
+File: web/src/pages/workspace/components/ToolboxItemFixOcr.vue - Replaced 'OCR输出的文本通常存在额外的换行符，导致翻译器错误。当前修复方法是检测每一行的结尾是否是字符（汉字/日文假名/韩文字符/英文字母/全角半角逗号），如果是的话则删除行尾的换行符。' with 'Text output by OCR often has extra newlines, causing translator errors. The current fix is to detect if the end of each line is a character (Chinese/Japanese/Korean/English/full-width or half-width comma), and if so, remove the newline at the end of the line.'.
+File: web/src/pages/workspace/components/ToolboxItemFixOcr.vue - Replaced '发生错误：${e}' with 'Error: ${e}'.
+File: web/src/pages/workspace/components/ToolboxItemFixOcr.vue - Replaced '修复' with 'Fix'.
+
+File: web/src/pages/workspace/components/ToolboxItemGlossary.vue - Replaced '已经将翻译结果复制到剪切板' with 'The translation result has been copied to the clipboard'.
+File: web/src/pages/workspace/components/ToolboxItemGlossary.vue - Replaced '未选择Sakura翻译器' with 'Sakura translator not selected'.
+File: web/src/pages/workspace/components/ToolboxItemGlossary.vue - Replaced '翻译器错误：${e}' with 'Translator error: ${e}'.
+File: web/src/pages/workspace/components/ToolboxItemGlossary.vue - Replaced '术语表辅助制作工具正在开发中，当前方案分为识别和翻译两步。' with 'The glossary-making tool is under development. The current plan is divided into two steps: recognition and translation.'.
+File: web/src/pages/workspace/components/ToolboxItemGlossary.vue - Replaced '识别阶段：根据片假名词汇出现频率判断可能是术语的词汇。' with 'Recognition stage: Identify possible terminology based on the frequency of katakana vocabulary.'.
+File: web/src/pages/workspace/components/ToolboxItemGlossary.vue - Replaced '翻译阶段：直接翻译日语词汇。' with 'Translation stage: Directly translate Japanese vocabulary.'.
+File: web/src/pages/workspace/components/ToolboxItemGlossary.vue - Replaced '注意，这是辅助制作，不是全自动生成，使用前务必检查结果。' with 'Note that this is an auxiliary production, not a fully automatic generation. Be sure to check the results before use.'.
+File: web/src/pages/workspace/components/ToolboxItemGlossary.vue - Replaced '次数下限' with 'Minimum number of times'.
+File: web/src/pages/workspace/components/ToolboxItemGlossary.vue - Replaced '操作' with 'Operation'.
+File: web/src/pages/workspace/components/ToolboxItemGlossary.vue - Replaced '复制术语表' with 'Copy glossary'.
+File: web/src/pages/workspace/components/ToolboxItemGlossary.vue - Replaced '百度翻译' with 'Baidu Translate'.
+File: web/src/pages/workspace/components/ToolboxItemGlossary.vue - Replaced '有道翻译' with 'Youdao Translate'.
+File: web/src/pages/workspace/components/ToolboxItemGlossary.vue - Replaced '未选中' with 'Not selected'.
+File: web/src/pages/workspace/components/ToolboxItemGlossary.vue - Replaced '选择翻译器' with 'Select translator'.
+File: web/src/pages/workspace/components/ToolboxItemGlossary.vue - Replaced '撤销删除' with 'Undo delete'.
+File: web/src/pages/workspace/components/ToolboxItemGlossary.vue - Replaced '移除' with 'Remove'.
+File: web/src/pages/workspace/components/ToolboxItemGlossary.vue - Replaced '请输入中文翻译' with 'Please enter Chinese translation'.
+File: web/src/pages/workspace/components/ToolboxItemGlossary.vue - Replaced '选择Sakura翻译器' with 'Select Sakura translator'.
+
+File: web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue - Replaced '删除' with 'Delete'.
+File: web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue - Replaced '${success}本小说已排队，${failed}本失败' with '${success} novels have been queued, ${failed} failed'.
+File: web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue - Replaced '排队成功' with 'Queue successful'.
+File: web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue - Replaced '排队失败：翻译任务已经存在' with 'Queue failed: translation task already exists'.
+File: web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue - Replaced '文件生成错误：${error}' with 'File generation error: ${error}'.
+File: web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue - Replaced '全部' with 'All'.
+File: web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue - Replaced '已完成' with 'Finished'.
+File: web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue - Replaced '未完成' with 'Unfinished'.
+File: web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue - Replaced '全部排队' with 'Queue all'.
+File: web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue - Replaced '状态' with 'Status'.
+File: web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue - Replaced '语言' with 'Language'.
+File: web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue - Replaced '总计' with 'Total'.
+File: web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue - Replaced '完成' with 'Finished'.
+File: web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue - Replaced '过期' with 'Expired'.
+File: web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue - Replaced '排队' with 'Queue'.
+File: web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue - Replaced '阅读' with 'Read'.
+File: web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue - Replaced '下载' with 'Download'.
+File: web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue - Replaced '真的要删除《${volume.id}》吗？' with 'Are you sure you want to delete '${volume.id}'?'.
+
+File: web/src/pages/workspace/components/LocalVolumeList.vue - Replaced '批量删除' with 'Batch delete'.
+File: web/src/pages/workspace/components/LocalVolumeList.vue - Replaced '没有选中小说' with 'No novel selected'.
+File: web/src/pages/workspace/components/LocalVolumeList.vue - Replaced '${success}本小说被打包，${failed}本失败' with '${success} novels were packaged, ${failed} failed'.
+File: web/src/pages/workspace/components/LocalVolumeList.vue - Replaced '没有选中小说' with 'No novel selected'.
+File: web/src/pages/workspace/components/LocalVolumeList.vue - Replaced '${success}本小说被删除，${failed}本失败' with '${success} novels were deleted, ${failed} failed'.
+File: web/src/pages/workspace/components/LocalVolumeList.vue - Replaced '本地小说' with 'Local novel'.
+File: web/src/pages/workspace/components/LocalVolumeList.vue - Replaced '下载' with 'Download'.
+File: web/src/pages/workspace/components/LocalVolumeList.vue - Replaced '搜索' with 'Search'.
+File: web/src/pages/workspace/components/LocalVolumeList.vue - Replaced '搜索文件名' with 'Search file name'.
+File: web/src/pages/workspace/components/LocalVolumeList.vue - Replaced '收藏' with 'Favorites'.
+File: web/src/pages/workspace/components/LocalVolumeList.vue - Replaced '排序' with 'Sort'.
+File: web/src/pages/workspace/components/LocalVolumeList.vue - Replaced '没有文件' with 'No files'.
+File: web/src/pages/workspace/components/LocalVolumeList.vue - Replaced '清空所有文件' with 'Clear all files'.
+File: web/src/pages/workspace/components/LocalVolumeList.vue - Replaced '这将清空你的浏览器里面保存的所有EPUB/TXT文件，包括已经翻译的章节和术语表，无法恢复。 你确定吗？' with 'This will clear all EPUB/TXT files saved in your browser, including translated chapters and glossaries, and cannot be recovered. Are you sure?'.
+File: web/src/pages/workspace/components/LocalVolumeList.vue - Replaced '确定' with 'Confirm'.
+
+File: web/src/pages/workspace/components/GptWorkerModal.vue - Replaced '不能为空' with 'cannot be empty'.
+File: web/src/pages/workspace/components/GptWorkerModal.vue - Replaced '名字' with 'Name'.
+File: web/src/pages/workspace/components/GptWorkerModal.vue - Replaced '名字不能重复' with 'Name cannot be repeated'.
+File: web/src/pages/workspace/components/GptWorkerModal.vue - Replaced '模型' with 'Model'.
+File: web/src/pages/workspace/components/GptWorkerModal.vue - Replaced '链接' with 'Link'.
+File: web/src/pages/workspace/components/GptWorkerModal.vue - Replaced '链接不合法' with 'Link is not valid'.
+File: web/src/pages/workspace/components/GptWorkerModal.vue - Replaced '有重复的Key，请确保使用的API支持并发' with 'There are duplicate keys, please ensure that the API used supports concurrency'.
+File: web/src/pages/workspace/components/GptWorkerModal.vue - Replaced '添加' with 'Add'.
+File: web/src/pages/workspace/components/GptWorkerModal.vue - Replaced '更新' with 'Update'.
+File: web/src/pages/workspace/components/GptWorkerModal.vue - Replaced 'GPT翻译器' with 'GPT Translator'.
+File: web/src/pages/workspace/components/GptWorkerModal.vue - Replaced '给你的翻译器起个名字' with 'Give your translator a name'.
+File: web/src/pages/workspace/components/GptWorkerModal.vue - Replaced '模型名称' with 'Model name'.
+File: web/src/pages/workspace/components/GptWorkerModal.vue - Replaced '兼容OpenAI的API链接，默认使用deepseek' with 'OpenAI-compatible API link, deepseek is used by default'.
+File: web/src/pages/workspace/components/GptWorkerModal.vue - Replaced '请输入Api key' with 'Please enter Api key'.
+File: web/src/pages/workspace/components/GptWorkerModal.vue - Replaced '# 链接例子：https://api.deepseek.com' with '# Link example: https://api.deepseek.com'.
+
+File: web/src/pages/workspace/components/SakuraWorkerModal.vue - Replaced '名字不能为空' with 'Name cannot be empty'.
+File: web/src/pages/workspace/components/SakuraWorkerModal.vue - Replaced '名字不能重复' with 'Name cannot be repeated'.
+File: web/src/pages/workspace/components/SakuraWorkerModal.vue - Replaced '链接不能为空' with 'Link cannot be empty'.
+File: web/src/pages/workspace/components/SakuraWorkerModal.vue - Replaced '链接不合法' with 'Link is not valid'.
+File: web/src/pages/workspace/components/SakuraWorkerModal.vue - Replaced '添加' with 'Add'.
+File: web/src/pages/workspace/components/SakuraWorkerModal.vue - Replaced '更新' with 'Update'.
+File: web/src/pages/workspace/components/SakuraWorkerModal.vue - Replaced 'Sakura翻译器' with 'Sakura Translator'.
+File: web/src/pages/workspace/components/SakuraWorkerModal.vue - Replaced '名字' with 'Name'.
+File: web/src/pages/workspace/components/SakuraWorkerModal.vue - Replaced '给你的翻译器起个名字' with 'Give your translator a name'.
+File: web/src/pages/workspace/components/SakuraWorkerModal.vue - Replaced '链接' with 'Link'.
+File: web/src/pages/workspace/components/SakuraWorkerModal.vue - Replaced '翻译器的链接' with 'Translator link'.
+File: web/src/pages/workspace/components/SakuraWorkerModal.vue - Replaced '分段长度' with 'Segment length'.
+File: web/src/pages/workspace/components/SakuraWorkerModal.vue - Replaced '前文长度' with 'Previous text length'.
+File: web/src/pages/workspace/components/SakuraWorkerModal.vue - Replaced '# 前文长度是临时功能，非默认500无法上传' with '# Previous text length is a temporary function, cannot upload if not the default 500'.
+File: web/src/pages/workspace/components/SakuraWorkerModal.vue - Replaced '# 分段长度还在测试中，非默认500无法上传' with '# Segment length is still under testing, cannot upload if not the default 500'.
+File: web/src/pages/workspace/components/SakuraWorkerModal.vue - Replaced '# 链接例子：http://127.0.0.1:8080' with '# Link example: http://127.0.0.1:8080'.
+
+File: web/src/pages/workspace/components/LocalVolumeListKatakana.vue - Replaced '删除' with 'Delete'.
+File: web/src/pages/workspace/components/LocalVolumeListKatakana.vue - Replaced '总计' with 'Total'.
+File: web/src/pages/workspace/components/LocalVolumeListKatakana.vue - Replaced '载入' with 'Load'.
+File: web/src/pages/workspace/components/LocalVolumeListKatakana.vue - Replaced '真的要删除《${volume.id}》吗？' with 'Are you sure you want to delete '${volume.id}'?'.
+
+File: web/src/pages/workspace/GptWorkspace.vue - Replaced '任务被翻译器占用' with 'The task is occupied by the translator'.
+File: web/src/pages/workspace/GptWorkspace.vue - Replaced '缓存清除' with 'Cache cleared'.
+File: web/src/pages/workspace/GptWorkspace.vue - Replaced 'GPT工作区' with 'GPT Workspace'.
+File: web/src/pages/workspace/GptWorkspace.vue - Replaced '使用教程' with 'User guide'.
+File: web/src/pages/workspace/GptWorkspace.vue - Replaced '不再支持GPT web，推荐使用deepseek API，价格很低。' with 'GPT web is no longer supported. It is recommended to use the deepseek API, the price is very low.'.
+File: web/src/pages/workspace/GptWorkspace.vue - Replaced '本地小说支持韩语等其他语种，网络小说/文库小说暂时只允许日语。' with 'Local novels support other languages such as Korean, while online novels/library novels only support Japanese for the time being.'.
+File: web/src/pages/workspace/GptWorkspace.vue - Replaced '翻译器' with 'Translator'.
+File: web/src/pages/workspace/GptWorkspace.vue - Replaced '添加翻译器' with 'Add translator'.
+File: web/src/pages/workspace/GptWorkspace.vue - Replaced '真的要清空缓存吗？' with 'Are you sure you want to clear the cache?'.
+File: web/src/pages/workspace/GptWorkspace.vue - Replaced '清空缓存' with 'Clear cache'.
+File: web/src/pages/workspace/GptWorkspace.vue - Replaced '没有翻译器' with 'No translator'.
+File: web/src/pages/workspace/GptWorkspace.vue - Replaced '任务队列' with 'Task queue'.
+File: web/src/pages/workspace/GptWorkspace.vue - Replaced '本地书架' with 'Local bookshelf'.
+File: web/src/pages/workspace/GptWorkspace.vue - Replaced '真的要清空队列吗？' with 'Are you sure you want to clear the queue?'.
+File: web/src/pages/workspace/GptWorkspace.vue - Replaced '清空队列' with 'Clear queue'.
+File: web/src/pages/workspace/GptWorkspace.vue - Replaced '没有任务' with 'No tasks'.
+
+File: web/src/pages/workspace/Interactive.vue - Replaced '百度' with 'Baidu'.
+File: web/src/pages/workspace/Interactive.vue - Replaced '有道' with 'Youdao'.
+File: web/src/pages/workspace/Interactive.vue - Replaced '未选择GPT翻译器' with 'GPT translator not selected'.
+File: web/src/pages/workspace/Interactive.vue - Replaced '未选择Sakura翻译器' with 'Sakura translator not selected'.
+File: web/src/pages/workspace/Interactive.vue - Replaced '翻译器错误：${e}' with 'Translator error: ${e}'.
+File: web/src/pages/workspace/Interactive.vue - Replaced '已经将翻译结果复制到剪切板' with 'The translation result has been copied to the clipboard'.
+File: web/src/pages/workspace/Interactive.vue - Replaced '交互翻译' with 'Interactive translation'.
+File: web/src/pages/workspace/Interactive.vue - Replaced '翻译' with 'Translate'.
+File: web/src/pages/workspace/Interactive.vue - Replaced '操作' with 'Operation'.
+File: web/src/pages/workspace/Interactive.vue - Replaced '翻译' with 'Translate'.
+File: web/src/pages/workspace/Interactive.vue - Replaced '清空' with 'Clear'.
+File: web/src/pages/workspace/Interactive.vue - Replaced '复制到剪贴板' with 'Copy to clipboard'.
+File: web/src/pages/workspace/Interactive.vue - Replaced '输入需要翻译的文本' with 'Enter the text to be translated'.
+File: web/src/pages/workspace/Interactive.vue - Replaced '翻译结果' with 'Translation results'.
+File: web/src/pages/workspace/Interactive.vue - Replaced '翻译历史' with 'Translation history'.
+File: web/src/pages/workspace/Interactive.vue - Replaced '清空' with 'Clear'.
+File: web/src/pages/workspace/Interactive.vue - Replaced '没有翻译历史' with 'No translation history'.
+File: web/src/pages/workspace/Interactive.vue - Replaced '日文' with 'Japanese'.
+File: web/src/pages/workspace/Interactive.vue - Replaced '中文' with 'Chinese'.
+
+File: web/src/pages/workspace/SakuraWorkspace.vue - Replaced '全部任务都已经完成' with 'All tasks have been completed'.
+File: web/src/pages/workspace/SakuraWorkspace.vue - Replaced '任务被翻译器占用' with 'The task is occupied by the translator'.
+File: web/src/pages/workspace/SakuraWorkspace.vue - Replaced '缓存清除' with 'Cache cleared'.
+File: web/src/pages/workspace/SakuraWorkspace.vue - Replaced 'Sakura工作区' with 'Sakura Workspace'.
+File: web/src/pages/workspace/SakuraWorkspace.vue - Replaced '本地部署教程' with 'Local deployment tutorial'.
+File: web/src/pages/workspace/SakuraWorkspace.vue - Replaced 'AutoDL教程' with 'AutoDL tutorial'.
+File: web/src/pages/workspace/SakuraWorkspace.vue - Replaced '控制台' with 'Console'.
+File: web/src/pages/workspace/SakuraWorkspace.vue - Replaced '允许上传的模型如下，禁止一切试图突破上传检查的操作。' with 'The allowed models to be uploaded are as follows, and any attempt to break through the upload check is prohibited.'.
+File: web/src/pages/workspace/SakuraWorkspace.vue - Replaced '国内镜像' with 'Domestic mirror'.
+File: web/src/pages/workspace/SakuraWorkspace.vue - Replaced '翻译器' with 'Translator'.
+File: web/src/pages/workspace/SakuraWorkspace.vue - Replaced '添加翻译器' with 'Add translator'.
+File: web/src/pages/workspace/SakuraWorkspace.vue - Replaced '真的要清空缓存吗？' with 'Are you sure you want to clear the cache?'.
+File: web/src/pages/workspace/SakuraWorkspace.vue - Replaced '清空缓存' with 'Clear cache'.
+File: web/src/pages/workspace/SakuraWorkspace.vue - Replaced '没有翻译器' with 'No translator'.
+File: web/src/pages/workspace/SakuraWorkspace.vue - Replaced '任务队列' with 'Task queue'.
+File: web/src/pages/workspace/SakuraWorkspace.vue - Replaced '本地书架' with 'Local bookshelf'.
+File: web/src/pages/workspace/SakuraWorkspace.vue - Replaced '真的要清空队列吗？' with 'Are you sure you want to clear the queue?'.
+File: web/src/pages/workspace/SakuraWorkspace.vue - Replaced '清空队列' with 'Clear queue'.
+File: web/src/pages/workspace/SakuraWorkspace.vue - Replaced '没有任务' with 'No tasks'.
+
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '没有选中小说' with 'No novel selected'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '${success}本小说被删除，${failed}本失败' with '${success} novels were deleted, ${failed} failed'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '无需移动' with 'No need to move'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '${success}本小说已移动，${failed}本失败' with '${success} novels have been moved, ${failed} failed'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '${success}本小说已排队，${failed}本失败' with '${success} novels have been queued, ${failed} failed'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '全选' with 'Select all'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '反选' with 'Invert selection'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '删除' with 'Delete'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '确定删除' with 'Confirm deletion'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '本小说' with 'novels'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '确定' with 'Confirm'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '已选择${selectedNovels.length}本小说' with 'Selected ${selectedNovels.length} novels'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '移动小说功能暂时关闭' with 'The move novel function is temporarily closed'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '移动小说（低配版，很慢，等到显示移动完成）' with 'Move novels (low-spec version, very slow, wait until the move is complete)'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '移动' with 'Move'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '生成翻译任务' with 'Generate translation task'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '常规' with 'Normal'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '过期' with 'Expired'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '重翻' with 'Re-translate'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '常规：只翻译未翻译的章节' with 'Normal: Only translate untranslated chapters'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '过期：翻译术语表过期的章节' with 'Expired: Translate chapters with expired glossaries'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '重翻：重翻全部章节' with 'Re-translate: Re-translate all chapters'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '重翻目录' with 'Re-translate table of contents'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '前5话' with 'First 5 chapters'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '倒序添加' with 'Add in reverse order'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '* 请确保你知道自己在干啥，不要随便使用危险功能' with '* Please make sure you know what you are doing, do not use dangerous functions casually'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '排队GPT' with 'Queue GPT'.
+File: web/src/pages/bookshelf/components/BookshelfWebControl.vue - Replaced '排队Sakura' with 'Queue Sakura'.
+
+File: web/src/pages/bookshelf/components/BookshelfLayout.vue - Replaced '我的收藏' with 'My favorites'.
+File: web/src/pages/bookshelf/components/BookshelfLayout.vue - Replaced '收藏夹' with 'Favorites'.
+
+File: web/src/pages/bookshelf/components/BookshelfMenuItem.vue - Replaced '编辑信息' with 'Edit information'.
+File: web/src/pages/bookshelf/components/BookshelfMenuItem.vue - Replaced '删除' with 'Delete'.
+File: web/src/pages/bookshelf/components/BookshelfMenuItem.vue - Replaced '收藏夹标题不能为空' with 'Bookshelf title cannot be empty'.
+File: web/src/pages/bookshelf/components/BookshelfMenuItem.vue - Replaced '收藏夹更新' with 'Bookshelf updated'.
+File: web/src/pages/bookshelf/components/BookshelfMenuItem.vue - Replaced '清空收藏夹失败，${failed}本未删除' with 'Failed to clear bookshelf, ${failed} items were not deleted'.
+File: web/src/pages/bookshelf/components/BookshelfMenuItem.vue - Replaced '收藏夹删除' with 'Bookshelf deleted'.
+File: web/src/pages/bookshelf/components/BookshelfMenuItem.vue - Replaced '编辑收藏夹' with 'Edit bookshelf'.
+File: web/src/pages/bookshelf/components/BookshelfMenuItem.vue - Replaced '标题' with 'Title'.
+File: web/src/pages/bookshelf/components/BookshelfMenuItem.vue - Replaced '收藏夹标题' with 'Bookshelf title'.
+File: web/src/pages/bookshelf/components/BookshelfMenuItem.vue - Replaced '确定' with 'Confirm'.
+File: web/src/pages/bookshelf/components/BookshelfMenuItem.vue - Replaced '删除收藏夹' with 'Delete bookshelf'.
+File: web/src/pages/bookshelf/components/BookshelfMenuItem.vue - Replaced '确定删除收藏夹' with 'Are you sure you want to delete the bookshelf'.
+File: web/src/pages/bookshelf/components/BookshelfMenuItem.vue - Replaced '注意，删除本地收藏夹的同时也会清空收藏夹内所有小说。' with 'Note that deleting a local bookshelf will also clear all the novels in it.'.
+
+File: web/src/pages/bookshelf/BookshelfWeb.vue - Replaced '来源' with 'Source'.
+File: web/src/pages/bookshelf/BookshelfWeb.vue - Replaced '成为小说家吧' with 'Let\'s become a novelist'.
+File: web/src/pages/bookshelf/BookshelfWeb.vue - Replaced '类型' with 'Type'.
+File: web/src/pages/bookshelf/BookshelfWeb.vue - Replaced '全部' with 'All'.
+File: web/src/pages/bookshelf/BookshelfWeb.vue - Replaced '连载中' with 'In serialization'.
+File: web/src/pages/bookshelf/BookshelfWeb.vue - Replaced '已完结' with 'Completed'.
+File: web/src/pages/bookshelf/BookshelfWeb.vue - Replaced '短篇' with 'Short story'.
+File: web/src/pages/bookshelf/BookshelfWeb.vue - Replaced '分级' with 'Rating'.
+File: web/src/pages/bookshelf/BookshelfWeb.vue - Replaced '一般向' with 'For all ages'.
+File: web/src/pages/bookshelf/BookshelfWeb.vue - Replaced '翻译' with 'Translate'.
+File: web/src/pages/bookshelf/BookshelfWeb.vue - Replaced '排序' with 'Sort'.
+File: web/src/pages/bookshelf/BookshelfWeb.vue - Replaced '收藏时间' with 'Favorite time'.
+File: web/src/pages/bookshelf/BookshelfWeb.vue - Replaced '更新时间' with 'Update time'.
+File: web/src/pages/bookshelf/BookshelfWeb.vue - Replaced '我的收藏 搜索：' with 'My favorites search:'.
+File: web/src/pages/bookshelf/BookshelfWeb.vue - Replaced '选择' with 'Select'.
+
+File: web/src/pages/home/components/Migrate.vue - Replaced '接收到消息' with 'Message received'.
+File: web/src/pages/home/components/Migrate.vue - Replaced '开始迁移数据' with 'Start migrating data'.
+File: web/src/pages/home/components/Migrate.vue - Replaced '发送migrate消息' with 'Send migrate message'.
+File: web/src/pages/home/components/Migrate.vue - Replaced '机翻站已切换到新的域名' with 'The machine translation station has been switched to a new domain name'.
+File: web/src/pages/home/components/Migrate.vue - Replaced '从books导入设置' with 'Import settings from books'.
+File: web/src/pages/home/components/Migrate.vue - Replaced '从books1导入设置' with 'Import settings from books1'.
+File: web/src/pages/home/components/Migrate.vue - Replaced '下载浏览器扩展（适配新域名）' with 'Download browser extension (adapted to the new domain name)'.
+
+File: web/src/pages/forum/ForumArticleEdit.vue - Replaced '小说交流' with 'Novel communication'.
+File: web/src/pages/forum/ForumArticleEdit.vue - Replaced '使用指南' with 'User guide'.
+File: web/src/pages/forum/ForumArticleEdit.vue - Replaced '反馈与建议' with 'Feedback and suggestions'.
+File: web/src/pages/forum/ForumArticleEdit.vue - Replaced '标题长度不能少于2个字符' with 'Title length cannot be less than 2 characters'.
+File: web/src/pages/forum/ForumArticleEdit.vue - Replaced '标题长度不能超过80个字符' with 'Title length cannot exceed 80 characters'.
+File: web/src/pages/forum/ForumArticleEdit.vue - Replaced '正文长度不能少于2个字符' with 'Content length cannot be less than 2 characters'.
+File: web/src/pages/forum/ForumArticleEdit.vue - Replaced '正文长度不能超过2万个字符' with 'Content length cannot exceed 20,000 characters'.
+File: web/src/pages/forum/ForumArticleEdit.vue - Replaced '未选择要发表的版块' with 'No section selected for publication'.
+File: web/src/pages/forum/ForumArticleEdit.vue - Replaced '载入失败' with 'Loading failed'.
+File: web/src/pages/forum/ForumArticleEdit.vue - Replaced '文章未载入，无法提交' with 'The article has not been loaded and cannot be submitted'.
+File: web/src/pages/forum/ForumArticleEdit.vue - Replaced '发布' with 'Publish'.
+File: web/src/pages/forum/ForumArticleEdit.vue - Replaced '更新' with 'Update'.
+File: web/src/pages/forum/ForumArticleEdit.vue - Replaced '编辑' with 'Edit'.
+File: web/src/pages/forum/ForumArticleEdit.vue - Replaced '文章' with 'Article'.
+File: web/src/pages/forum/ForumArticleEdit.vue - Replaced '标题' with 'Title'.
+File: web/src/pages/forum/ForumArticleEdit.vue - Replaced '请输入标题' with 'Please enter the title'.
+File: web/src/pages/forum/ForumArticleEdit.vue - Replaced '版块' with 'Section'.
+File: web/src/pages/forum/ForumArticleEdit.vue - Replaced '正文' with 'Content'.
+File: web/src/pages/forum/ForumArticleEdit.vue - Replaced '请输入正文' with 'Please enter the content'.
+File: web/src/pages/forum/ForumArticleEdit.vue - Replaced '提交' with 'Submit'.
+
+File: web/src/pages/list/ReadHistoryList.vue - Replaced '清空' with 'Clear'.
+File: web/src/pages/list/ReadHistoryList.vue - Replaced '删除' with 'Delete'.
+File: web/src/pages/list/ReadHistoryList.vue - Replaced '阅读历史' with 'Reading history'.
+File: web/src/pages/list/ReadHistoryList.vue - Replaced '真的要清空记录吗？' with 'Are you sure you want to clear the records?'.
+File: web/src/pages/list/ReadHistoryList.vue - Replaced '清空记录' with 'Clear records'.
+File: web/src/pages/list/ReadHistoryList.vue - Replaced '继续记录历史' with 'Continue recording history'.
+File: web/src/pages/list/ReadHistoryList.vue - Replaced '暂停记录历史' with 'Pause recording history'.
+File: web/src/pages/list/ReadHistoryList.vue - Replaced '注意：历史功能已暂停' with 'Note: The history function has been suspended'.
+
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '选项' with 'Options'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '常规' with 'Normal'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '过期' with 'Expired'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '重翻' with 'Re-translate'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '源站同步' with 'Sync with source'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '常规：只翻译未翻译的章节' with 'Normal: Only translate untranslated chapters'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '过期：翻译术语表过期的章节' with 'Expired: Translate chapters with expired glossaries'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '重翻：重翻全部章节' with 'Re-translate: Re-translate all chapters'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '源站同步：用于原作者修改了原文的情况导致不一致的情况，可能清空现有翻译，慎用！!' with 'Sync from source station: used when the original author modifies the original text, which may cause inconsistencies. It may clear the existing translation, use with caution!'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '重翻目录' with 'Re-translate table of contents'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '* 请确保你知道自己在干啥，不要随便使用危险功能' with '* Please make sure you know what you are doing, do not use dangerous functions casually'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '范围' with 'Range'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '从' with 'From'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '到' with 'To'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '均分' with 'Equally divided'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '个任务' with 'tasks'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '章节序号看下面目录方括号里的数字。“从0到10”表示从第0章到第9章，不包含第10章。均分任务只对排队生效，最大为10。' with 'For the chapter number, see the number in square brackets in the table of contents below. "From 0 to 10" means from chapter 0 to chapter 9, not including chapter 10. The equal task is only effective for queuing, and the maximum is 10.'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '操作' with 'Operation'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '下载设置' with 'Download settings'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '语言' with 'Language'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '翻译' with 'Translate'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '文件' with 'File'.
+File: web/src/pages/novel/components/TranslateOptions.vue - Replaced '# 某些EPUB阅读器无法正确显示日文段落的浅色字体' with '# Some EPUB readers cannot correctly display light-colored fonts in Japanese paragraphs'.
+
+File: web/src/pages/novel/WebNovelEdit.vue - Replaced '载入失败' with 'Loading failed'.
+File: web/src/pages/novel/WebNovelEdit.vue - Replaced '小说未载入，无法提交' with 'The novel has not been loaded and cannot be submitted'.
+File: web/src/pages/novel/WebNovelEdit.vue - Replaced '编辑' with 'Edit'.
+File: web/src/pages/novel/WebNovelEdit.vue - Replaced '编辑网络小说' with 'Edit web novel'.
+File: web/src/pages/novel/WebNovelEdit.vue - Replaced '文库链接' with 'Wenku link'.
+File: web/src/pages/novel/WebNovelEdit.vue - Replaced '文库版ID' with 'Wenku version ID'.
+File: web/src/pages/novel/WebNovelEdit.vue - Replaced '日文标题' with 'Japanese title'.
+File: web/src/pages/novel/WebNovelEdit.vue - Replaced '中文标题' with 'Chinese title'.
+File: web/src/pages/novel/WebNovelEdit.vue - Replaced '日文简介' with 'Japanese introduction'.
+File: web/src/pages/novel/WebNovelEdit.vue - Replaced '中文简介' with 'Chinese introduction'.
+File: web/src/pages/novel/WebNovelEdit.vue - Replaced '目录' with 'Table of contents'.
+File: web/src/pages/novel/WebNovelEdit.vue - Replaced '注意，手动编辑目录可能会被其他人覆盖。如果你不满意目录的翻译，可以先用翻译器重翻试试。' with 'Note that manual editing of the table of contents may be overwritten by others. If you are not satisfied with the translation of the table of contents, you can try re-translating it with a translator first.'.
+File: web/src/pages/novel/WebNovelEdit.vue - Replaced '提交' with 'Submit'.
+
+File: server/src/main/kotlin/api/RouteWenkuNovel.kt - Replaced '请先登录' with 'Please log in first'.
+File: server/src/main/kotlin/api/RouteWenkuNovel.kt - Replaced '术语表未更改' with 'Glossary not changed'.
+File: server/src/main/kotlin/api/RouteWenkuNovel.kt - Replaced '卷已存在' with 'Volume already exists'.
+File: server/src/main/kotlin/api/RouteWenkuNovel.kt - Replaced '解包失败，原因：' with 'Unpacking failed, reason:'.
+File: server/src/main/kotlin/api/RouteWenkuNovel.kt - Replaced '未设置翻译类型' with 'Translation type not set'.
+File: server/src/main/kotlin/api/RouteWenkuNovel.kt - Replaced '不支持的类型' with 'Unsupported type'.
+File: server/src/main/kotlin/api/RouteWenkuNovel.kt - Replaced '卷不存在' with 'Volume does not exist'.
+File: server/src/main/kotlin/api/RouteWenkuNovel.kt - Replaced '章节不存在' with 'Chapter does not exist'.
+File: server/src/main/kotlin/api/RouteWenkuNovel.kt - Replaced '旧版Sakura不再允许上传' with 'Older versions of Sakura are no longer allowed to be uploaded'.
+File: server/src/main/kotlin/api/RouteWenkuNovel.kt - Replaced '术语表无效' with 'Glossary is invalid'.
+File: server/src/main/kotlin/api/RouteWenkuNovel.kt - Replaced '翻译行数不匹配' with 'The number of translated lines does not match'.
+
+File: web/src/pages/util.ts - Replaced '成功' with 'Success'.
+File: web/src/pages/util.ts - Replaced '失败:' with 'Failed:'.
+File: web/src/pages/util.ts - Replaced '// 优先使用 navigator 提供的复制方法' with '// Prefer to use the copy method provided by the navigator'.
+File: web/src/pages/util.ts - Replaced '// 回退到传统复制方法' with '// Fallback to traditional copy method'.
+File: web/src/pages/util.ts - Replaced '// 创建临时可编辑元素，使用div元素避免弹出输入法' with '// Create a temporary editable element, use a div element to avoid popping up the input method'.
+File: web/src/pages/util.ts - Replaced '// modal 内的复制，需要一个 modal 内部的元素作为 parentNode 来储存临时文本' with '// For copying within a modal, a modal-internal element is needed as a parentNode to store the temporary text'.
+
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '没有选中小说' with 'No novel selected'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '${success}本小说被删除，${failed}本失败' with '${success} novels were deleted, ${failed} failed'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '${success}本小说机翻被打包，${failed}本失败' with '${success} machine-translated novels were packaged, ${failed} failed'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '${success}本小说原文被打包，${failed}本失败' with '${success} original novels were packaged, ${failed} failed'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '无需移动' with 'No need to move'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '${success}本小说已移动，${failed}本失败' with '${success} novels have been moved, ${failed} failed'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '${success}本小说已排队，${failed}本失败' with '${success} novels have been queued, ${failed} failed'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '全选' with 'Select all'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '反选' with 'Invert selection'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '下载原文' with 'Download original text'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '下载机翻' with 'Download machine translation'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '下载设置' with 'Download settings'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '删除' with 'Delete'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '确定删除' with 'Confirm deletion'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '本小说' with 'novels'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '确定' with 'Confirm'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '已选择${selectedIds.length}本小说' with 'Selected ${selectedIds.length} novels'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '移动小说功能暂时关闭' with 'The move novel function is temporarily closed'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '移动小说' with 'Move novel'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '移动' with 'Move'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '生成翻译任务' with 'Generate translation task'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '选项' with 'Options'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '过期' with 'Expired'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '重翻' with 'Re-translate'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '过期：翻译术语表过期的章节' with 'Expired: Translate chapters with expired glossaries'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '重翻：重翻全部章节' with 'Re-translate: Re-translate all chapters'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '倒序添加' with 'Add in reverse order'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '操作' with 'Operation'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '排队GPT' with 'Queue GPT'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '排队Sakura' with 'Queue Sakura'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '下载设置' with 'Download settings'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '语言' with 'Language'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '翻译' with 'Translate'.
+File: web/src/pages/bookshelf/components/BookshelfLocalControl.vue - Replaced '# 某些EPUB阅读器无法正确显示日文段落的浅色字体' with '# Some EPUB readers cannot correctly display light-colored fonts in Japanese paragraphs'.

--- a/web/src/components/CButton.vue
+++ b/web/src/components/CButton.vue
@@ -18,11 +18,11 @@ const onClick = async (e: MouseEvent) => {
   if (!props.onAction) return;
 
   if (props.requireLogin === true && !whoami.value.isSignedIn) {
-    message.info('请先登录');
+    message.info('Please log in first');
     return;
   }
   if (running.value) {
-    message.warning('处理中...');
+    message.warning('Processing...');
     return;
   }
   const ret = props.onAction(e);

--- a/web/src/pages/bookshelf/BookshelfWeb.vue
+++ b/web/src/pages/bookshelf/BookshelfWeb.vue
@@ -24,10 +24,10 @@ const { setting } = Locator.settingRepository();
 
 const options = computed(() => [
   {
-    label: '来源',
+    label: 'Source',
     tags: [
       'Kakuyomu',
-      '成为小说家吧',
+      "Let's become a novelist",
       'Novelup',
       'Hameln',
       'Pixiv',
@@ -36,22 +36,22 @@ const options = computed(() => [
     multiple: true,
   },
   {
-    label: '类型',
-    tags: ['全部', '连载中', '已完结', '短篇'],
+    label: 'Type',
+    tags: ['All', 'In serialization', 'Completed', 'Short story'],
   },
   {
-    label: '分级',
-    tags: ['全部', '一般向', 'R18'],
+    label: 'Rating',
+    tags: ['All', 'For all ages', 'R18'],
   },
   {
-    label: '翻译',
-    tags: ['全部', 'GPT', 'Sakura'],
+    label: 'Translate',
+    tags: ['All', 'GPT', 'Sakura'],
   },
   {
-    label: '排序',
+    label: 'Sort',
     tags: setting.value.favoriteCreateTimeFirst
-      ? ['收藏时间', '更新时间']
-      : ['更新时间', '收藏时间'],
+      ? ['Favorite time', 'Update time']
+      : ['Update time', 'Favorite time'],
   },
 ]);
 
@@ -59,12 +59,12 @@ const loader = computed<Loader<WebNovelOutlineDto>>(() => {
   const { favoredId } = props;
   return (page, query, selected) => {
     if (query !== '') {
-      document.title = '我的收藏 搜索：' + query;
+      document.title = 'My favorites search: ' + query;
     }
     const parseProviderBitFlags = (n: number): string => {
       const providerMap: { [key: string]: string } = {
         Kakuyomu: 'kakuyomu',
-        成为小说家吧: 'syosetu',
+        "Let's become a novelist": 'syosetu',
         Novelup: 'novelup',
         Hameln: 'hameln',
         Pixiv: 'pixiv',
@@ -77,12 +77,12 @@ const loader = computed<Loader<WebNovelOutlineDto>>(() => {
     };
 
     const parseSort = (sortIndex: number): 'create' | 'update' => {
-      const sortOption = (options.value.find((opt) => opt.label === '排序')
+      const sortOption = (options.value.find((opt) => opt.label === 'Sort')
         ?.tags ?? [])[sortIndex];
       switch (sortOption) {
-        case '收藏时间':
+        case 'Favorite time':
           return 'create';
-        case '更新时间':
+        case 'Update time':
         default:
           return 'update';
       }
@@ -138,7 +138,7 @@ const novelListRef = ref<InstanceType<typeof NovelListWeb>>();
   <bookshelf-layout :menu-key="`web/${favoredId}`">
     <n-flex style="margin-bottom: 24px">
       <c-button
-        label="选择"
+        label="Select"
         :icon="ChecklistOutlined"
         @action="showControlPanel = !showControlPanel"
       />

--- a/web/src/pages/bookshelf/components/BookshelfLayout.vue
+++ b/web/src/pages/bookshelf/components/BookshelfLayout.vue
@@ -8,11 +8,11 @@ const isWideScreen = useIsWideScreen();
 <template>
   <c-layout :sidebar="isWideScreen" :sidebar-width="320" class="layout-content">
     <div style="flex: auto">
-      <n-h1>我的收藏</n-h1>
+      <n-h1>My favorites</n-h1>
       <slot />
     </div>
     <template #sidebar>
-      <section-header title="收藏夹">
+      <section-header title="Favorites">
         <bookshelf-add-button />
       </section-header>
       <bookshelf-menu :value="menuKey" />

--- a/web/src/pages/bookshelf/components/BookshelfLocalControl.vue
+++ b/web/src/pages/bookshelf/components/BookshelfLocalControl.vue
@@ -29,7 +29,7 @@ const showDeleteModal = ref(false);
 const openDeleteModal = () => {
   const ids = props.selectedIds;
   if (ids.length === 0) {
-    message.info('没有选中小说');
+    message.info('No novel selected');
     return;
   }
   showDeleteModal.value = true;
@@ -38,7 +38,7 @@ const openDeleteModal = () => {
 const deleteSelected = async () => {
   const ids = props.selectedIds;
   const { success, failed } = await store.deleteVolumes(ids);
-  message.info(`${success}本小说被删除，${failed}本失败`);
+  message.info(`${success} novels were deleted, ${failed} failed`);
 };
 
 // 下载小说
@@ -47,21 +47,21 @@ const showDownloadModal = ref(false);
 const downloadSelected = async () => {
   const ids = props.selectedIds;
   if (ids.length === 0) {
-    message.info('没有选中小说');
+    message.info('No novel selected');
     return;
   }
   const { success, failed } = await store.downloadVolumes(ids);
-  message.info(`${success}本小说机翻被打包，${failed}本失败`);
+  message.info(`${success} machine-translated novels were packaged, ${failed} failed`);
 };
 
 const downloadRawSelected = async () => {
   const ids = props.selectedIds;
   if (ids.length === 0) {
-    message.info('没有选中小说');
+    message.info('No novel selected');
     return;
   }
   const { success, failed } = await store.downloadRawVolumes(ids);
-  message.info(`${success}本小说原文被打包，${failed}本失败`);
+  message.info(`${success} original novels were packaged, ${failed} failed`);
 };
 
 // 移动小说
@@ -72,12 +72,12 @@ const targetFavoredId = ref(props.favoredId);
 const moveToFavored = async () => {
   const novels = props.selectedIds;
   if (novels.length === 0) {
-    message.info('没有选中小说');
+    message.info('No novel selected');
     return;
   }
 
   if (targetFavoredId.value === props.favoredId) {
-    message.info('无需移动');
+    message.info('No need to move');
     return;
   }
 
@@ -96,7 +96,7 @@ const moveToFavored = async () => {
   }
   const success = novels.length - failed;
 
-  message.info(`${success}本小说已移动，${failed}本失败`);
+  message.info(`${success} novels have been moved, ${failed} failed`);
   await store.loadVolumes();
 };
 
@@ -108,7 +108,7 @@ const shouldTopJob = useKeyModifier('Control');
 const queueJobs = (type: 'gpt' | 'sakura') => {
   let ids = props.selectedIds;
   if (ids.length === 0) {
-    message.info('没有选中小说');
+    message.info('No novel selected');
     return;
   }
 
@@ -121,7 +121,7 @@ const queueJobs = (type: 'gpt' | 'sakura') => {
     type,
     shouldTop: shouldTopJob.value ?? false,
   });
-  message.info(`${success}本小说已排队，${failed}本失败`);
+  message.info(`${success} novels have been queued, ${failed} failed`);
 };
 </script>
 
@@ -132,12 +132,12 @@ const queueJobs = (type: 'gpt' | 'sakura') => {
         <n-flex align="baseline">
           <n-button-group size="small">
             <c-button
-              label="全选"
+              label="Select all"
               :round="false"
               @action="$emit('selectAll')"
             />
             <c-button
-              label="反选"
+              label="Invert selection"
               :round="false"
               @action="$emit('invertSelection')"
             />
@@ -145,24 +145,24 @@ const queueJobs = (type: 'gpt' | 'sakura') => {
 
           <n-button-group size="small">
             <c-button
-              label="下载原文"
+              label="Download original text"
               :round="false"
               @action="downloadRawSelected"
             />
             <c-button
-              label="下载机翻"
+              label="Download machine translation"
               :round="false"
               @action="downloadSelected"
             />
             <c-button
-              label="下载设置"
+              label="Download settings"
               :round="false"
               @action="showDownloadModal = true"
             />
           </n-button-group>
 
           <c-button
-            label="删除"
+            label="Delete"
             secondary
             :round="false"
             size="small"
@@ -170,32 +170,32 @@ const queueJobs = (type: 'gpt' | 'sakura') => {
             @click="openDeleteModal"
           />
           <c-modal
-            :title="`确定删除 ${
+            :title="`Confirm deletion ${
               selectedIds.length === 1
                 ? selectedIds[0]
-                : `${selectedIds.length}本小说`
+                : `${selectedIds.length} novels`
             }？`"
             v-model:show="showDeleteModal"
           >
             <template #action>
-              <c-button label="确定" type="primary" @action="deleteSelected" />
+              <c-button label="Confirm" type="primary" @action="deleteSelected" />
             </template>
           </c-modal>
         </n-flex>
 
-        <n-text depth="3"> 已选择{{ selectedIds.length }}本小说 </n-text>
+        <n-text depth="3"> Selected {{ selectedIds.length }} novels </n-text>
       </n-flex>
     </n-list-item>
 
     <n-list-item v-if="favoreds.local.length > 1">
-      <n-p>移动小说功能暂时关闭</n-p>
+      <n-p>The move novel function is temporarily closed</n-p>
       <n-flex v-if="false" vertical>
-        <b>移动小说</b>
+        <b>Move novel</b>
 
         <n-radio-group v-model:value="targetFavoredId">
           <n-flex align="center">
             <c-button
-              label="移动"
+              label="Move"
               size="small"
               :round="false"
               @action="moveToFavored"
@@ -220,45 +220,45 @@ const queueJobs = (type: 'gpt' | 'sakura') => {
       "
     >
       <n-flex vertical>
-        <b>生成翻译任务</b>
+        <b>Generate translation task</b>
 
-        <c-action-wrapper title="选项">
+        <c-action-wrapper title="Options">
           <n-flex size="small">
             <n-tooltip trigger="hover">
               <template #trigger>
                 <n-flex :size="0" :wrap="false">
                   <tag-button
-                    label="过期"
+                    label="Expired"
                     :checked="translateLevel === 'expire'"
                     @update:checked="translateLevel = 'expire'"
                   />
                   <tag-button
-                    label="重翻"
+                    label="Re-translate"
                     type="warning"
                     :checked="translateLevel === 'all'"
                     @update:checked="translateLevel = 'all'"
                   />
                 </n-flex>
               </template>
-              过期：翻译术语表过期的章节<br />
-              重翻：重翻全部章节<br />
+              Expired: Translate chapters with expired glossaries<br />
+              Re-translate: Re-translate all chapters<br />
             </n-tooltip>
 
-            <tag-button label="倒序添加" v-model:checked="reverseOrder" />
+            <tag-button label="Add in reverse order" v-model:checked="reverseOrder" />
           </n-flex>
         </c-action-wrapper>
 
-        <c-action-wrapper title="操作">
+        <c-action-wrapper title="Operation">
           <n-button-group size="small">
             <c-button
               v-if="setting.enabledTranslator.includes('gpt')"
-              label="排队GPT"
+              label="Queue GPT"
               :round="false"
               @action="queueJobs('gpt')"
             />
             <c-button
               v-if="setting.enabledTranslator.includes('sakura')"
-              label="排队Sakura"
+              label="Queue Sakura"
               :round="false"
               @action="queueJobs('sakura')"
             />
@@ -268,16 +268,16 @@ const queueJobs = (type: 'gpt' | 'sakura') => {
     </n-list-item>
   </n-list>
 
-  <c-modal title="下载设置" v-model:show="showDownloadModal">
+  <c-modal title="Download settings" v-model:show="showDownloadModal">
     <n-flex vertical size="large">
-      <c-action-wrapper title="语言">
+      <c-action-wrapper title="Language">
         <c-radio-group
           v-model:value="setting.downloadFormat.mode"
           :options="Setting.downloadModeOptions"
         />
       </c-action-wrapper>
 
-      <c-action-wrapper title="翻译">
+      <c-action-wrapper title="Translate">
         <n-flex>
           <c-radio-group
             v-model:value="setting.downloadFormat.translationsMode"
@@ -292,7 +292,7 @@ const queueJobs = (type: 'gpt' | 'sakura') => {
       </c-action-wrapper>
 
       <n-text depth="3" style="font-size: 12px">
-        # 某些EPUB阅读器无法正确显示日文段落的浅色字体
+        # Some EPUB readers cannot correctly display light-colored fonts in Japanese paragraphs
       </n-text>
     </n-flex>
   </c-modal>

--- a/web/src/pages/bookshelf/components/BookshelfMenuItem.vue
+++ b/web/src/pages/bookshelf/components/BookshelfMenuItem.vue
@@ -22,11 +22,11 @@ const getOptions = () => {
   if (id === 'all') {
     return [];
   } else if (id === 'default') {
-    return [{ label: '编辑信息', key: 'edit' }];
+    return [{ label: 'Edit information', key: 'edit' }];
   } else {
     return [
-      { label: '编辑信息', key: 'edit' },
-      { label: '删除', key: 'delete' },
+      { label: 'Edit information', key: 'edit' },
+      { label: 'Delete', key: 'delete' },
     ];
   }
 };
@@ -48,7 +48,7 @@ const formRules: FormRules = {
   title: [
     {
       validator: (_rule: FormItemRule, value: string) => value.length > 0,
-      message: '收藏夹标题不能为空',
+      message: 'Bookshelf title cannot be empty',
       trigger: 'input',
     },
   ],
@@ -70,7 +70,7 @@ const updateFavored = async () => {
     favoredRepository.updateFavored(type, id, title).then(() => {
       showEditModal.value = false;
     }),
-    '收藏夹更新',
+    'Bookshelf updated',
     message,
   );
 };
@@ -81,7 +81,7 @@ const deleteFavoredNovels = async () => {
       store.volumes.filter((it) => it.favoredId === id).map(({ id }) => id),
     );
     if (failed > 0) {
-      throw new Error(`清空收藏夹失败，${failed}本未删除`);
+      throw new Error(`Failed to clear bookshelf, ${failed} items were not deleted`);
     }
   }
 };
@@ -92,7 +92,7 @@ const deleteFavored = () =>
     deleteFavoredNovels()
       .then(() => favoredRepository.deleteFavored(type, id))
       .then(() => (showDeleteModal.value = false)),
-    '收藏夹删除',
+    'Bookshelf deleted',
     message,
   );
 </script>
@@ -115,7 +115,7 @@ const deleteFavored = () =>
     </n-flex>
   </router-link>
 
-  <c-modal v-model:show="showEditModal" title="编辑收藏夹">
+  <c-modal v-model:show="showEditModal" title="Edit bookshelf">
     <n-form
       ref="formRef"
       :model="formValue"
@@ -123,10 +123,10 @@ const deleteFavored = () =>
       label-placement="left"
       label-width="auto"
     >
-      <n-form-item-row label="标题" path="title">
+      <n-form-item-row label="Title" path="title">
         <n-input
           v-model:value="formValue.title"
-          placeholder="收藏夹标题"
+          placeholder="Bookshelf title"
           :input-props="{ spellcheck: false }"
         />
       </n-form-item-row>
@@ -134,7 +134,7 @@ const deleteFavored = () =>
 
     <template #action>
       <c-button
-        label="确定"
+        label="Confirm"
         require-login
         type="primary"
         @action="updateFavored"
@@ -142,16 +142,16 @@ const deleteFavored = () =>
     </template>
   </c-modal>
 
-  <c-modal v-model:show="showDeleteModal" title="删除收藏夹">
-    确定删除收藏夹[{{ title }}]吗？
+  <c-modal v-model:show="showDeleteModal" title="Delete bookshelf">
+    Are you sure you want to delete the bookshelf [{{ title }}]?
     <n-text v-if="type === 'local'">
       <br />
-      注意，删除本地收藏夹的同时也会清空收藏夹内所有小说。
+      Note that deleting a local bookshelf will also clear all the novels in it.
     </n-text>
 
     <template #action>
       <c-button
-        label="确定"
+        label="Confirm"
         require-login
         type="primary"
         @action="deleteFavored"

--- a/web/src/pages/bookshelf/components/BookshelfWebControl.vue
+++ b/web/src/pages/bookshelf/components/BookshelfWebControl.vue
@@ -26,7 +26,7 @@ const showDeleteModal = ref(false);
 const openDeleteModal = () => {
   const novels = props.selectedNovels;
   if (novels.length === 0) {
-    message.info('没有选中小说');
+    message.info('No novel selected');
     return;
   }
   showDeleteModal.value = true;
@@ -48,7 +48,7 @@ const deleteSelected = async () => {
   }
   const success = novels.length - failed;
 
-  message.info(`${success}本小说被删除，${failed}本失败`);
+  message.info(`${success} novels were deleted, ${failed} failed`);
 };
 
 // 移动小说
@@ -57,12 +57,12 @@ const targetFavoredId = ref(props.favoredId);
 const moveToFavored = async () => {
   const novels = props.selectedNovels;
   if (novels.length === 0) {
-    message.info('没有选中小说');
+    message.info('No novel selected');
     return;
   }
 
   if (targetFavoredId.value === props.favoredId) {
-    message.info('无需移动');
+    message.info('No need to move');
     return;
   }
 
@@ -81,7 +81,7 @@ const moveToFavored = async () => {
   }
   const success = novels.length - failed;
 
-  message.info(`${success}本小说已移动，${failed}本失败`);
+  message.info(`${success} novels have been moved, ${failed} failed`);
   window.location.reload();
 };
 
@@ -95,7 +95,7 @@ const shouldTopJob = useKeyModifier('Control');
 const queueJobs = (type: 'gpt' | 'sakura') => {
   let novels = props.selectedNovels;
   if (novels.length === 0) {
-    message.info('没有选中小说');
+    message.info('No novel selected');
     return;
   }
 
@@ -130,7 +130,7 @@ const queueJobs = (type: 'gpt' | 'sakura') => {
     }
   });
   const success = novels.length - failed;
-  message.info(`${success}本小说已排队，${failed}本失败`);
+  message.info(`${success} novels have been queued, ${failed} failed`);
 };
 </script>
 
@@ -141,19 +141,19 @@ const queueJobs = (type: 'gpt' | 'sakura') => {
         <n-flex align="baseline">
           <n-button-group size="small">
             <c-button
-              label="全选"
+              label="Select all"
               :round="false"
               @action="$emit('selectAll')"
             />
             <c-button
-              label="反选"
+              label="Invert selection"
               :round="false"
               @action="$emit('invertSelection')"
             />
           </n-button-group>
 
           <c-button
-            label="删除"
+            label="Delete"
             secondary
             :round="false"
             size="small"
@@ -161,32 +161,32 @@ const queueJobs = (type: 'gpt' | 'sakura') => {
             @click="openDeleteModal"
           />
           <c-modal
-            :title="`确定删除 ${
+            :title="`Confirm deletion ${
               selectedNovels.length === 1
                 ? selectedNovels[0].titleZh ?? selectedNovels[0].titleJp
-                : `${selectedNovels.length}本小说`
+                : `${selectedNovels.length} novels`
             }？`"
             v-model:show="showDeleteModal"
           >
             <template #action>
-              <c-button label="确定" type="primary" @action="deleteSelected" />
+              <c-button label="Confirm" type="primary" @action="deleteSelected" />
             </template>
           </c-modal>
         </n-flex>
 
-        <n-text depth="3"> 已选择{{ selectedNovels.length }}本小说 </n-text>
+        <n-text depth="3"> Selected {{ selectedNovels.length }} novels </n-text>
       </n-flex>
     </n-list-item>
 
     <n-list-item v-if="favoreds.web.length > 1">
-      <n-p>移动小说功能暂时关闭</n-p>
+      <n-p>The move novel function is temporarily closed</n-p>
       <n-flex v-if="false" vertical>
-        <b>移动小说（低配版，很慢，等到显示移动完成）</b>
+        <b>Move novels (low-spec version, very slow, wait until the move is complete)</b>
 
         <n-radio-group v-model:value="targetFavoredId">
           <n-flex align="center">
             <c-button
-              label="移动"
+              label="Move"
               size="small"
               :round="false"
               @action="moveToFavored"
@@ -211,58 +211,58 @@ const queueJobs = (type: 'gpt' | 'sakura') => {
       "
     >
       <n-flex vertical>
-        <b>生成翻译任务</b>
+        <b>Generate translation task</b>
 
         <n-flex size="small">
           <n-tooltip trigger="hover">
             <template #trigger>
               <n-flex :size="0" :wrap="false">
                 <tag-button
-                  label="常规"
+                  label="Normal"
                   :checked="translateLevel === 'normal'"
                   @update:checked="translateLevel = 'normal'"
                 />
                 <tag-button
-                  label="过期"
+                  label="Expired"
                   :checked="translateLevel === 'expire'"
                   @update:checked="translateLevel = 'expire'"
                 />
                 <tag-button
-                  label="重翻"
+                  label="Re-translate"
                   type="warning"
                   :checked="translateLevel === 'all'"
                   @update:checked="translateLevel = 'all'"
                 />
               </n-flex>
             </template>
-            常规：只翻译未翻译的章节<br />
-            过期：翻译术语表过期的章节<br />
-            重翻：重翻全部章节<br />
+            Normal: Only translate untranslated chapters<br />
+            Expired: Translate chapters with expired glossaries<br />
+            Re-translate: Re-translate all chapters<br />
           </n-tooltip>
 
-          <tag-button label="重翻目录" v-model:checked="forceMetadata" />
-          <tag-button label="前5话" v-model:checked="first5" />
-          <tag-button label="倒序添加" v-model:checked="reverseOrder" />
+          <tag-button label="Re-translate table of contents" v-model:checked="forceMetadata" />
+          <tag-button label="First 5 chapters" v-model:checked="first5" />
+          <tag-button label="Add in reverse order" v-model:checked="reverseOrder" />
 
           <n-text
             v-if="translateLevel === 'all'"
             type="warning"
             style="font-size: 12px; flex-basis: 100%"
           >
-            <b> * 请确保你知道自己在干啥，不要随便使用危险功能 </b>
+            <b> * Please make sure you know what you are doing, do not use dangerous functions casually </b>
           </n-text>
         </n-flex>
 
         <n-button-group size="small">
           <c-button
             v-if="setting.enabledTranslator.includes('gpt')"
-            label="排队GPT"
+            label="Queue GPT"
             :round="false"
             @action="queueJobs('gpt')"
           />
           <c-button
             v-if="setting.enabledTranslator.includes('sakura')"
-            label="排队Sakura"
+            label="Queue Sakura"
             :round="false"
             @action="queueJobs('sakura')"
           />

--- a/web/src/pages/forum/ForumArticleEdit.vue
+++ b/web/src/pages/forum/ForumArticleEdit.vue
@@ -25,13 +25,13 @@ const store = articleId !== undefined ? useArticleStore(articleId) : undefined;
 
 const articleCategoryOptions = whoami.value.asAdmin
   ? [
-      { value: 'General', label: '小说交流' },
-      { value: 'Guide', label: '使用指南' },
-      { value: 'Support', label: '反馈与建议' },
+      { value: 'General', label: 'Novel communication' },
+      { value: 'Guide', label: 'User guide' },
+      { value: 'Support', label: 'Feedback and suggestions' },
     ]
   : [
-      { value: 'General', label: '小说交流' },
-      { value: 'Support', label: '反馈与建议' },
+      { value: 'General', label: 'Novel communication' },
+      { value: 'Support', label: 'Feedback and suggestions' },
     ];
 
 const allowSubmit = ref(articleId === undefined);
@@ -46,12 +46,12 @@ const formRules: FormRules = {
     {
       validator: (_rule: FormItemRule, value: string) =>
         value.trim().length >= 2,
-      message: '标题长度不能少于2个字符',
+      message: 'Title length cannot be less than 2 characters',
       trigger: 'input',
     },
     {
       validator: (_rule: FormItemRule, value: string) => value.length <= 80,
-      message: '标题长度不能超过80个字符',
+      message: 'Title length cannot exceed 80 characters',
       trigger: 'input',
     },
   ],
@@ -59,12 +59,12 @@ const formRules: FormRules = {
     {
       validator: (_rule: FormItemRule, value: string) =>
         value.trim().length >= 2,
-      message: '正文长度不能少于2个字符',
+      message: 'Content length cannot be less than 2 characters',
       trigger: 'input',
     },
     {
       validator: (_rule: FormItemRule, value: string) => value.length <= 20_000,
-      message: '正文长度不能超过2万个字符',
+      message: 'Content length cannot exceed 20,000 characters',
       trigger: 'input',
     },
   ],
@@ -72,7 +72,7 @@ const formRules: FormRules = {
     {
       validator: (_rule: FormItemRule, value: string | undefined) =>
         value !== undefined,
-      message: '未选择要发表的版块',
+      message: 'No section selected for publication',
       trigger: 'input',
     },
   ],
@@ -88,13 +88,13 @@ store?.loadArticle()?.then((result) => {
     };
     allowSubmit.value = true;
   } else {
-    message.error('载入失败');
+    message.error('Loading failed');
   }
 });
 
 const submit = async () => {
   if (!allowSubmit.value) {
-    message.warning('文章未载入，无法提交');
+    message.warning('The article has not been loaded and cannot be submitted');
     return;
   }
 
@@ -110,7 +110,7 @@ const submit = async () => {
         draftRepo.removeDraft(draftId);
         router.push({ path: `/forum/${id}` });
       }),
-      '发布',
+      'Publish',
       message,
     );
   } else {
@@ -119,7 +119,7 @@ const submit = async () => {
         draftRepo.removeDraft(draftId);
         router.push({ path: `/forum/${articleId}` });
       }),
-      '更新',
+      'Update',
       message,
     );
   }
@@ -128,7 +128,7 @@ const submit = async () => {
 
 <template>
   <div class="layout-content">
-    <n-h1>{{ articleId === undefined ? '发布' : '编辑' }}文章</n-h1>
+    <n-h1>{{ articleId === undefined ? 'Publish' : 'Edit' }} Article</n-h1>
     <n-form
       ref="formRef"
       :model="formValue"
@@ -136,27 +136,27 @@ const submit = async () => {
       :label-placement="isWideScreen ? 'left' : 'top'"
       label-width="auto"
     >
-      <n-form-item-row path="title" label="标题">
+      <n-form-item-row path="title" label="Title">
         <n-input
           v-model:value="formValue.title"
-          placeholder="请输入标题"
+          placeholder="Please enter the title"
           maxlength="80"
           show-count
           :input-props="{ spellcheck: false }"
         />
       </n-form-item-row>
-      <n-form-item-row path="category" label="版块">
+      <n-form-item-row path="category" label="Section">
         <c-radio-group
           v-model:value="formValue.category"
           :options="articleCategoryOptions"
         />
       </n-form-item-row>
-      <n-form-item-row path="content" label="正文">
+      <n-form-item-row path="content" label="Content">
         <MarkdownEditor
           mode="article"
           :draft-id="draftId"
           v-model:value="formValue.content"
-          placeholder="请输入正文"
+          placeholder="Please enter the content"
           :autosize="{ minRows: 8 }"
           maxlength="20000"
           style="width: 100%"
@@ -165,7 +165,7 @@ const submit = async () => {
     </n-form>
 
     <c-button
-      label="提交"
+      label="Submit"
       :icon="UploadOutlined"
       require-login
       size="large"

--- a/web/src/pages/home/components/Migrate.vue
+++ b/web/src/pages/home/components/Migrate.vue
@@ -7,11 +7,11 @@ const inOldDomain = location.hostname.includes('fishhawk');
 const open = (url: string) => window.open(url);
 
 window.addEventListener('message', (message) => {
-  console.log('接收到消息', message);
+  console.log('Message received', message);
   const { origin, data } = message;
 
   if (origin.endsWith('fishhawk.top') && data.type == 'migrate') {
-    console.log('开始迁移数据', data);
+    console.log('Start migrating data', data);
 
     if (data.auth) localStorage.setItem(LSKey.Auth, data.auth);
     if (data.blacklist) localStorage.setItem(LSKey.Blacklist, data.blacklist);
@@ -36,7 +36,7 @@ if (inOldDomain && window.opener) {
     setting: localStorage.getItem(LSKey.Setting),
     settingReader: localStorage.getItem(LSKey.SettingReader),
   };
-  console.log('发送migrate消息');
+  console.log('Send migrate message');
   window.opener.postMessage(msg, 'https://n.novelia.cc');
   window.close();
 }
@@ -45,7 +45,7 @@ if (inOldDomain && window.opener) {
 <template>
   <n-p v-if="inOldDomain" style="margin: 0px 0px 4px">
     <b>
-      机翻站已切换到新的域名
+      The machine translation station has been switched to a new domain name
       <n-a href="https://n.novelia.cc/">{{ newDomain }}</n-a>
     </b>
   </n-p>
@@ -55,7 +55,7 @@ if (inOldDomain && window.opener) {
       size="small"
       type="warning"
       secondary
-      label="从books导入设置"
+      label="Import settings from books"
       @click="open('https://books.fishhawk.top')"
       style="font-weight: 700"
     />
@@ -65,7 +65,7 @@ if (inOldDomain && window.opener) {
       size="small"
       type="warning"
       secondary
-      label="从books1导入设置"
+      label="Import settings from books1"
       @click="open('https://books1.fishhawk.top')"
       style="font-weight: 700"
     />
@@ -77,7 +77,7 @@ if (inOldDomain && window.opener) {
       secondary
       tag="a"
       href="https://n.novelia.cc/files-extra/extension.v1.0.12.zip"
-      label="下载浏览器扩展（适配新域名）"
+      label="Download browser extension (adapted to the new domain name)"
       style="font-weight: 700"
     />
   </n-flex>

--- a/web/src/pages/list/ReadHistoryList.vue
+++ b/web/src/pages/list/ReadHistoryList.vue
@@ -29,7 +29,7 @@ const clearHistory = () =>
     readHistoryRepository.clearReadHistoryWeb().then(() => {
       window.location.reload();
     }),
-    '清空',
+    'Clear',
     message,
   );
 
@@ -38,36 +38,36 @@ const deleteHistory = (providerId: string, novelId: string) =>
     readHistoryRepository.deleteReadHistoryWeb(providerId, novelId).then(() => {
       window.location.reload();
     }),
-    '删除',
+    'Delete',
     message,
   );
 </script>
 
 <template>
   <div class="layout-content">
-    <n-h1>阅读历史</n-h1>
+    <n-h1>Reading history</n-h1>
 
     <n-flex style="margin-bottom: 24px">
       <c-button-confirm
-        hint="真的要清空记录吗？"
-        label="清空记录"
+        hint="Are you sure you want to clear the records?"
+        label="Clear records"
         :icon="DeleteOutlineOutlined"
         @action="clearHistory()"
       />
       <c-button
         v-if="readHistoryPaused"
-        label="继续记录历史"
+        label="Continue recording history"
         @action="readHistoryRepository.resumeReadHistory()"
       />
       <c-button
         v-else
-        label="暂停记录历史"
+        label="Pause recording history"
         @action="readHistoryRepository.pauseReadHistory()"
       />
     </n-flex>
 
     <n-text v-if="readHistoryPaused" type="warning">
-      注意：历史功能已暂停
+      Note: The history function has been suspended
     </n-text>
 
     <novel-page :page="page" :loader="loader" :options="[]" v-slot="{ items }">
@@ -75,7 +75,7 @@ const deleteHistory = (providerId: string, novelId: string) =>
         <template #action="item">
           <c-button
             size="tiny"
-            label="删除"
+            label="Delete"
             style="margin-top: 2px"
             @action="deleteHistory(item.providerId, item.novelId)"
           />

--- a/web/src/pages/novel/WebNovelEdit.vue
+++ b/web/src/pages/novel/WebNovelEdit.vue
@@ -47,13 +47,13 @@ store.loadNovel().then((result) => {
     };
     allowSubmit.value = true;
   } else {
-    message.error('载入失败');
+    message.error('Loading failed');
   }
 });
 
 const submit = async () => {
   if (!allowSubmit.value) {
-    message.warning('小说未载入，无法提交');
+    message.warning('The novel has not been loaded and cannot be submitted');
     return;
   }
 
@@ -71,7 +71,7 @@ const submit = async () => {
       .then(() => {
         router.push({ path: `/novel/${providerId}/${novelId}` });
       }),
-    '编辑',
+    'Edit',
     message,
   );
 };
@@ -79,7 +79,7 @@ const submit = async () => {
 
 <template>
   <div class="layout-content">
-    <n-h1>编辑网络小说</n-h1>
+    <n-h1>Edit web novel</n-h1>
 
     <n-form
       ref="formRef"
@@ -87,21 +87,21 @@ const submit = async () => {
       :label-placement="isWideScreen ? 'left' : 'top'"
       label-width="auto"
     >
-      <n-form-item path="wenkuId" label="文库链接">
+      <n-form-item path="wenkuId" label="Wenku link">
         <n-input-group>
           <n-input-group-label>wenku/</n-input-group-label>
           <n-input
             v-model:value="formValue.wenkuId"
-            placeholder="文库版ID"
+            placeholder="Wenku version ID"
             :input-props="{ spellcheck: false }"
           />
         </n-input-group>
       </n-form-item>
 
-      <n-form-item label="日文标题">
+      <n-form-item label="Japanese title">
         {{ formValue.titleJp }}
       </n-form-item>
-      <n-form-item path="title" label="中文标题">
+      <n-form-item path="title" label="Chinese title">
         <n-input
           v-model:value="formValue.title"
           :placeholder="formValue.titleJp"
@@ -109,10 +109,10 @@ const submit = async () => {
         />
       </n-form-item>
 
-      <n-form-item label="日文简介">
+      <n-form-item label="Japanese introduction">
         {{ formValue.introductionJp }}
       </n-form-item>
-      <n-form-item path="introduction" label="中文简介">
+      <n-form-item path="introduction" label="Chinese introduction">
         <n-input
           v-model:value="formValue.introduction"
           :placeholder="formValue.introductionJp"
@@ -123,10 +123,10 @@ const submit = async () => {
       </n-form-item>
     </n-form>
 
-    <n-h2 prefix="bar">目录</n-h2>
+    <n-h2 prefix="bar">Table of contents</n-h2>
     <n-p>
       <n-text type="error">
-        注意，手动编辑目录可能会被其他人覆盖。如果你不满意目录的翻译，可以先用翻译器重翻试试。
+        Note that manual editing of the table of contents may be overwritten by others. If you are not satisfied with the translation of the table of contents, you can try re-translating it with a translator first.
       </n-text>
     </n-p>
     <n-table :bordered="false" :bottom-bordered="false" style="width: 100%">
@@ -154,7 +154,7 @@ const submit = async () => {
     <n-divider />
 
     <c-button
-      label="提交"
+      label="Submit"
       :icon="UploadOutlined"
       require-login
       size="large"

--- a/web/src/pages/novel/components/TranslateOptions.vue
+++ b/web/src/pages/novel/components/TranslateOptions.vue
@@ -40,47 +40,47 @@ const showDownloadModal = ref(false);
 
 <template>
   <n-flex vertical>
-    <c-action-wrapper title="选项">
+    <c-action-wrapper title="Options">
       <n-flex size="small">
         <n-tooltip trigger="hover" style="max-width: 200px">
           <template #trigger>
             <n-flex :size="0" :wrap="false">
               <tag-button
-                label="常规"
+                label="Normal"
                 :checked="translateLevel === 'normal'"
                 @update:checked="translateLevel = 'normal'"
               />
               <tag-button
-                label="过期"
+                label="Expired"
                 :checked="translateLevel === 'expire'"
                 @update:checked="translateLevel = 'expire'"
               />
               <tag-button
-                label="重翻"
+                label="Re-translate"
                 type="warning"
                 :checked="translateLevel === 'all'"
                 @update:checked="translateLevel = 'all'"
               />
               <tag-button
                 v-if="gnid.type === 'web'"
-                label="源站同步"
+                label="Sync with source"
                 type="warning"
                 :checked="translateLevel === 'sync'"
                 @update:checked="translateLevel = 'sync'"
               />
             </n-flex>
           </template>
-          常规：只翻译未翻译的章节<br />
-          过期：翻译术语表过期的章节<br />
-          重翻：重翻全部章节<br />
+          Normal: Only translate untranslated chapters<br />
+          Expired: Translate chapters with expired glossaries<br />
+          Re-translate: Re-translate all chapters<br />
           <template v-if="gnid.type === 'web'">
-            源站同步：用于原作者修改了原文的情况导致不一致的情况，可能清空现有翻译，慎用！!
+            Sync from source station: used when the original author modifies the original text, which may cause inconsistencies. It may clear the existing translation, use with caution!
           </template>
         </n-tooltip>
 
         <tag-button
           v-if="gnid.type === 'web'"
-          label="重翻目录"
+          label="Re-translate table of contents"
           v-model:checked="forceMetadata"
         />
 
@@ -89,19 +89,19 @@ const showDownloadModal = ref(false);
           type="warning"
           style="font-size: 12px; flex-basis: 100%"
         >
-          <b> * 请确保你知道自己在干啥，不要随便使用危险功能 </b>
+          <b> * Please make sure you know what you are doing, do not use dangerous functions casually </b>
         </n-text>
       </n-flex>
     </c-action-wrapper>
 
     <c-action-wrapper
       v-if="gnid.type === 'web' || gnid.type === 'local'"
-      title="范围"
+      title="Range"
     >
       <n-flex style="text-align: center">
         <div>
           <n-input-group>
-            <n-input-group-label size="small">从</n-input-group-label>
+            <n-input-group-label size="small">From</n-input-group-label>
             <n-input-number
               size="small"
               v-model:value="startIndex"
@@ -110,7 +110,7 @@ const showDownloadModal = ref(false);
               :min="0"
               style="width: 60px"
             />
-            <n-input-group-label size="small">到</n-input-group-label>
+            <n-input-group-label size="small">To</n-input-group-label>
             <n-input-number
               size="small"
               v-model:value="endIndex"
@@ -122,7 +122,7 @@ const showDownloadModal = ref(false);
         </div>
         <div>
           <n-input-group>
-            <n-input-group-label size="small">均分</n-input-group-label>
+            <n-input-group-label size="small">Equally divided</n-input-group-label>
             <n-input-number
               size="small"
               v-model:value="taskNumber"
@@ -131,7 +131,7 @@ const showDownloadModal = ref(false);
               :max="gnid.type === 'local' ? 65536 : 10"
               style="width: 40px"
             />
-            <n-input-group-label size="small">个任务</n-input-group-label>
+            <n-input-group-label size="small">tasks</n-input-group-label>
           </n-input-group>
         </div>
 
@@ -141,15 +141,15 @@ const showDownloadModal = ref(false);
               <n-icon depth="4" :component="InfoOutlined" />
             </n-button>
           </template>
-          章节序号看下面目录方括号里的数字。“从0到10”表示从第0章到第9章，不包含第10章。均分任务只对排队生效，最大为10。
+          For the chapter number, see the number in square brackets in the table of contents below. "From 0 to 10" means from chapter 0 to chapter 9, not including chapter 10. The equal task is only effective for queuing, and the maximum is 10.
         </n-tooltip>
       </n-flex>
     </c-action-wrapper>
 
-    <c-action-wrapper v-if="gnid.type !== 'local'" title="操作">
+    <c-action-wrapper v-if="gnid.type !== 'local'" title="Operation">
       <n-button-group size="small">
         <c-button
-          label="下载设置"
+          label="Download settings"
           :round="false"
           @action="showDownloadModal = true"
         />
@@ -157,16 +157,16 @@ const showDownloadModal = ref(false);
       </n-button-group>
     </c-action-wrapper>
 
-    <c-modal title="下载设置" v-model:show="showDownloadModal">
+    <c-modal title="Download settings" v-model:show="showDownloadModal">
       <n-flex vertical size="large">
-        <c-action-wrapper title="语言">
+        <c-action-wrapper title="Language">
           <c-radio-group
             v-model:value="setting.downloadFormat.mode"
             :options="Setting.downloadModeOptions"
           />
         </c-action-wrapper>
 
-        <c-action-wrapper title="翻译">
+        <c-action-wrapper title="Translate">
           <n-flex>
             <c-radio-group
               v-model:value="setting.downloadFormat.translationsMode"
@@ -180,7 +180,7 @@ const showDownloadModal = ref(false);
           </n-flex>
         </c-action-wrapper>
 
-        <c-action-wrapper v-if="gnid.type === 'web'" title="文件">
+        <c-action-wrapper v-if="gnid.type === 'web'" title="File">
           <c-radio-group
             v-model:value="setting.downloadFormat.type"
             :options="Setting.downloadTypeOptions"
@@ -202,7 +202,7 @@ const showDownloadModal = ref(false);
         </c-action-wrapper>
 
         <n-text depth="3" style="font-size: 12px">
-          # 某些EPUB阅读器无法正确显示日文段落的浅色字体
+          # Some EPUB readers cannot correctly display light-colored fonts in Japanese paragraphs
         </n-text>
       </n-flex>
     </c-modal>

--- a/web/src/pages/util.ts
+++ b/web/src/pages/util.ts
@@ -41,10 +41,10 @@ export const doAction = (
 ) =>
   promise
     .then(() => {
-      message.info(label + '成功');
+      message.info(label + ' Success');
     })
     .catch(async (e) => {
-      message.error(label + '失败:' + (await formatError(e)));
+      message.error(label + ' Failed:' + (await formatError(e)));
     });
 
 type KeyPredicate = (event: KeyboardEvent) => boolean;
@@ -77,7 +77,7 @@ export const copyToClipBoard = async (
   text: string,
   parentNode?: HTMLElement | null,
 ) => {
-  // 优先使用 navigator 提供的复制方法
+  // Prefer to use the copy method provided by the navigator
   try {
     if (navigator.clipboard?.writeText) {
       await navigator.clipboard.writeText(text);
@@ -85,8 +85,8 @@ export const copyToClipBoard = async (
     }
   } catch {}
 
-  // 回退到传统复制方法
-  // 创建临时可编辑元素，使用div元素避免弹出输入法
+  // Fallback to traditional copy method
+  // Create a temporary editable element, use a div element to avoid popping up the input method
   const textEl = document.createElement('div');
   textEl.innerText = text;
   Object.assign(textEl.style, {
@@ -97,7 +97,7 @@ export const copyToClipBoard = async (
   });
   textEl.contentEditable = 'true';
 
-  // modal 内的复制，需要一个 modal 内部的元素作为 parentNode 来储存临时文本
+  // For copying within a modal, a modal-internal element is needed as a parentNode to store the temporary text
   const targetNode = parentNode ?? document.body;
   targetNode.appendChild(textEl);
 

--- a/web/src/pages/workspace/GptWorkspace.vue
+++ b/web/src/pages/workspace/GptWorkspace.vue
@@ -37,7 +37,7 @@ const getNextJob = () => {
 
 const deleteJob = (task: string) => {
   if (processedJobs.value.has(task)) {
-    message.error('任务被翻译器占用');
+    message.error('The task is occupied by the translator');
     return;
   }
   workspace.deleteJob(task);
@@ -77,18 +77,18 @@ const onProgressUpdated = (
 const clearCache = async () =>
   doAction(
     Locator.cachedSegRepository().then((repo) => repo.clear('gpt-seg-cache')),
-    '缓存清除',
+    'Cache cleared',
     message,
   );
 </script>
 
 <template>
   <div class="layout-content">
-    <n-h1>GPT工作区</n-h1>
+    <n-h1>GPT Workspace</n-h1>
 
     <bulletin>
       <n-flex>
-        <c-a to="/forum/64f3d63f794cbb1321145c07" target="_blank">使用教程</c-a>
+        <c-a to="/forum/64f3d63f794cbb1321145c07" target="_blank">User guide</c-a>
         /
         <n-a href="https://chat.deepseek.com" target="_blank">
           DeepSeek Chat
@@ -98,19 +98,19 @@ const clearCache = async () =>
           DeepSeek API
         </n-a>
       </n-flex>
-      <n-p>不再支持GPT web，推荐使用deepseek API，价格很低。</n-p>
-      <n-p>本地小说支持韩语等其他语种，网络小说/文库小说暂时只允许日语。</n-p>
+      <n-p>GPT web is no longer supported. It is recommended to use the deepseek API, the price is very low.</n-p>
+      <n-p>Local novels support other languages such as Korean, while online novels/library novels only support Japanese for the time being.</n-p>
     </bulletin>
 
-    <section-header title="翻译器">
+    <section-header title="Translator">
       <c-button
-        label="添加翻译器"
+        label="Add translator"
         :icon="PlusOutlined"
         @action="showCreateWorkerModal = true"
       />
       <c-button-confirm
-        hint="真的要清空缓存吗？"
-        label="清空缓存"
+        hint="Are you sure you want to clear the cache?"
+        label="Clear cache"
         :icon="DeleteOutlineOutlined"
         @action="clearCache"
       />
@@ -118,7 +118,7 @@ const clearCache = async () =>
 
     <n-empty
       v-if="workspaceRef.workers.length === 0"
-      description="没有翻译器"
+      description="No translator"
     />
     <n-list>
       <vue-draggable
@@ -136,20 +136,20 @@ const clearCache = async () =>
       </vue-draggable>
     </n-list>
 
-    <section-header title="任务队列">
+    <section-header title="Task queue">
       <c-button
-        label="本地书架"
+        label="Local bookshelf"
         :icon="BookOutlined"
         @action="showLocalVolumeDrawer = true"
       />
       <c-button-confirm
-        hint="真的要清空队列吗？"
-        label="清空队列"
+        hint="Are you sure you want to clear the queue?"
+        label="Clear queue"
         :icon="DeleteOutlineOutlined"
         @action="deleteAllJobs"
       />
     </section-header>
-    <n-empty v-if="workspaceRef.jobs.length === 0" description="没有任务" />
+    <n-empty v-if="workspaceRef.jobs.length === 0" description="No tasks" />
     <n-list>
       <vue-draggable
         v-model="workspaceRef.jobs"

--- a/web/src/pages/workspace/Interactive.vue
+++ b/web/src/pages/workspace/Interactive.vue
@@ -11,8 +11,8 @@ const textZh = ref('');
 
 const translatorId = ref<TranslatorId>('sakura');
 const translationOptions: { label: string; value: TranslatorId }[] = [
-  { label: '百度', value: 'baidu' },
-  { label: '有道', value: 'youdao' },
+  { label: 'Baidu', value: 'baidu' },
+  { label: 'Youdao', value: 'youdao' },
   { label: 'GPT', value: 'gpt' },
   { label: 'Sakura', value: 'sakura' },
 ];
@@ -50,7 +50,7 @@ const translate = async () => {
       (it) => it.id === selectedGptWorkerId.value,
     );
     if (worker === undefined) {
-      message.error('未选择GPT翻译器');
+      message.error('GPT translator not selected');
       return;
     }
     selectedWorker = worker;
@@ -66,7 +66,7 @@ const translate = async () => {
       (it) => it.id === selectedSakuraWorkerId.value,
     );
     if (worker === undefined) {
-      message.error('未选择Sakura翻译器');
+      message.error('Sakura translator not selected');
       return;
     }
     selectedWorker = worker;
@@ -90,7 +90,7 @@ const translate = async () => {
     });
     textZh.value = linesZh.join('\n');
   } catch (e: unknown) {
-    message.error(`翻译器错误：${e}`);
+    message.error(`Translator error: ${e}`);
   }
 
   savedTranslation.value.push({
@@ -107,7 +107,7 @@ const clearTranslation = () => {
 };
 const copyToClipboard = () => {
   navigator.clipboard.writeText(textZh.value);
-  message.info('已经将翻译结果复制到剪切板');
+  message.info('The translation result has been copied to the clipboard');
 };
 const clearSavedTranslation = () => {
   savedTranslation.value = [];
@@ -116,10 +116,10 @@ const clearSavedTranslation = () => {
 
 <template>
   <div class="layout-content">
-    <n-h1>交互翻译</n-h1>
+    <n-h1>Interactive translation</n-h1>
 
     <n-flex vertical>
-      <c-action-wrapper title="翻译">
+      <c-action-wrapper title="Translate">
         <n-flex vertical>
           <c-radio-group
             v-model:value="translatorId"
@@ -167,17 +167,17 @@ const clearSavedTranslation = () => {
         </n-flex>
       </c-action-wrapper>
 
-      <c-action-wrapper title="操作">
+      <c-action-wrapper title="Operation">
         <n-flex style="margin-bottom: 16px">
           <n-button-group size="small">
-            <c-button label="翻译" :round="false" @action="translate" />
-            <c-button label="清空" :round="false" @action="clearTranslation" />
+            <c-button label="Translate" :round="false" @action="translate" />
+            <c-button label="Clear" :round="false" @action="clearTranslation" />
           </n-button-group>
 
           <glossary-button :value="glossary" :round="false" size="small" />
 
           <c-button
-            label="复制到剪贴板"
+            label="Copy to clipboard"
             :round="false"
             size="small"
             @action="copyToClipboard"
@@ -189,7 +189,7 @@ const clearSavedTranslation = () => {
     <n-input-group>
       <n-input
         v-model:value="textJp"
-        placeholder="输入需要翻译的文本"
+        placeholder="Enter the text to be translated"
         type="textarea"
         :autosize="{ minRows: 15 }"
         show-count
@@ -201,7 +201,7 @@ const clearSavedTranslation = () => {
       <n-input
         v-model:value="textZh"
         readonly
-        placeholder="翻译结果"
+        placeholder="Translation results"
         type="textarea"
         :autosize="{ minRows: 15 }"
         show-count
@@ -210,11 +210,11 @@ const clearSavedTranslation = () => {
       />
     </n-input-group>
 
-    <section-header title="翻译历史">
-      <c-button label="清空" @action="clearSavedTranslation" />
+    <section-header title="Translation history">
+      <c-button label="Clear" @action="clearSavedTranslation" />
     </section-header>
 
-    <n-empty v-if="savedTranslation.length === 0" description="没有翻译历史" />
+    <n-empty v-if="savedTranslation.length === 0" description="No translation history" />
     <n-list>
       <n-list-item v-for="t of savedTranslation" :key="t.id">
         <n-thing content-indented>
@@ -236,13 +236,13 @@ const clearSavedTranslation = () => {
 
           <template #description>
             <n-collapse style="margin-top: 16px">
-              <n-collapse-item title="日文">
+              <n-collapse-item title="Japanese">
                 <template v-for="line of t.jp.split('\n')" :key="line">
                   {{ line }}
                   <br />
                 </template>
               </n-collapse-item>
-              <n-collapse-item title="中文">
+              <n-collapse-item title="Chinese">
                 <template v-for="line of t.zh.split('\n')" :key="line">
                   {{ line }}
                   <br />

--- a/web/src/pages/workspace/SakuraWorkspace.vue
+++ b/web/src/pages/workspace/SakuraWorkspace.vue
@@ -36,7 +36,7 @@ const getNextJob = () => {
   if (job !== undefined) {
     processedJobs.value.set(job.task, job);
   } else if (processedJobs.value.size === 0 && setting.value.workspaceSound) {
-    // 全部任务都已经完成
+    // All tasks have been completed
     new Audio(SoundAllTaskCompleted).play();
   }
   return job;
@@ -44,7 +44,7 @@ const getNextJob = () => {
 
 const deleteJob = (task: string) => {
   if (processedJobs.value.has(task)) {
-    message.error('任务被翻译器占用');
+    message.error('The task is occupied by the translator');
     return;
   }
   workspace.deleteJob(task);
@@ -87,36 +87,36 @@ const clearCache = async () =>
     Locator.cachedSegRepository().then((repo) =>
       repo.clear('sakura-seg-cache'),
     ),
-    '缓存清除',
+    'Cache cleared',
     message,
   );
 </script>
 
 <template>
   <div class="layout-content">
-    <n-h1>Sakura工作区</n-h1>
+    <n-h1>Sakura Workspace</n-h1>
 
     <bulletin>
       <n-flex>
         <c-a to="/forum/656d60530286f15e3384fcf8" target="_blank">
-          本地部署教程
+          Local deployment tutorial
         </c-a>
         /
         <span>
           <c-a to="/forum/65719bf16843e12bd3a4dc98" target="_blank">
-            AutoDL教程
+            AutoDL tutorial
           </c-a>
           :
           <n-a
             href="https://www.autodl.com/console/instance/list"
             target="_blank"
           >
-            控制台
+            Console
           </n-a>
         </span>
       </n-flex>
 
-      <n-p>允许上传的模型如下，禁止一切试图突破上传检查的操作。</n-p>
+      <n-p>The allowed models to be uploaded are as follows, and any attempt to break through the upload check is prohibited.</n-p>
       <n-ul>
         <n-li
           v-for="({ repo }, model) in SakuraTranslator.allowModels"
@@ -134,7 +134,7 @@ const clearCache = async () =>
             target="_blank"
             :href="`https://hf-mirror.com/${repo}/blob/main/${model}.gguf`"
           >
-            国内镜像
+            Domestic mirror
           </n-a>
           ]
           {{ model }}
@@ -142,15 +142,15 @@ const clearCache = async () =>
       </n-ul>
     </bulletin>
 
-    <section-header title="翻译器">
+    <section-header title="Translator">
       <c-button
-        label="添加翻译器"
+        label="Add translator"
         :icon="PlusOutlined"
         @action="showCreateWorkerModal = true"
       />
       <c-button-confirm
-        hint="真的要清空缓存吗？"
-        label="清空缓存"
+        hint="Are you sure you want to clear the cache?"
+        label="Clear cache"
         :icon="DeleteOutlineOutlined"
         @action="clearCache"
       />
@@ -158,7 +158,7 @@ const clearCache = async () =>
 
     <n-empty
       v-if="workspaceRef.workers.length === 0"
-      description="没有翻译器"
+      description="No translator"
     />
     <n-list>
       <vue-draggable
@@ -176,20 +176,20 @@ const clearCache = async () =>
       </vue-draggable>
     </n-list>
 
-    <section-header title="任务队列">
+    <section-header title="Task queue">
       <c-button
-        label="本地书架"
+        label="Local bookshelf"
         :icon="BookOutlined"
         @action="showLocalVolumeDrawer = true"
       />
       <c-button-confirm
-        hint="真的要清空队列吗？"
-        label="清空队列"
+        hint="Are you sure you want to clear the queue?"
+        label="Clear queue"
         :icon="DeleteOutlineOutlined"
         @action="deleteAllJobs"
       />
     </section-header>
-    <n-empty v-if="workspaceRef.jobs.length === 0" description="没有任务" />
+    <n-empty v-if="workspaceRef.jobs.length === 0" description="No tasks" />
     <n-list>
       <vue-draggable
         v-model="workspaceRef.jobs"

--- a/web/src/pages/workspace/components/GptWorkerModal.vue
+++ b/web/src/pages/workspace/components/GptWorkerModal.vue
@@ -44,25 +44,25 @@ const formValue = ref(initFormValue());
 
 const emptyCheck = (name: string) => ({
   validator: (rule: FormItemRule, value: string) => value.trim().length > 0,
-  message: name + '不能为空',
+  message: name + ' cannot be empty',
   trigger: 'input',
 });
 
 const formRules: FormRules = {
   id: [
-    emptyCheck('名字'),
+    emptyCheck('Name'),
     {
       validator: (rule: FormItemRule, value: string) =>
         workspaceRef.value.workers
           .filter(({ id }) => id !== props.worker?.id)
           .find(({ id }) => id === value) === undefined,
-      message: '名字不能重复',
+      message: 'Name cannot be repeated',
       trigger: 'input',
     },
   ],
-  model: [emptyCheck('模型')],
+  model: [emptyCheck('Model')],
   endpoint: [
-    emptyCheck('链接'),
+    emptyCheck('Link'),
     {
       validator: (rule: FormItemRule, value: string) => {
         try {
@@ -72,7 +72,7 @@ const formRules: FormRules = {
           return false;
         }
       },
-      message: '链接不合法',
+      message: 'Link is not valid',
       trigger: 'input',
     },
   ],
@@ -84,7 +84,7 @@ const formRules: FormRules = {
         workspaceRef.value.workers
           .filter(({ id }) => id !== props.worker?.id)
           .find(({ key }) => key === value) === undefined,
-      message: '有重复的Key，请确保使用的API支持并发',
+      message: 'There are duplicate keys, please ensure that the API used supports concurrency',
       trigger: 'input',
     },
   ],
@@ -119,14 +119,14 @@ const submit = async () => {
   }
 };
 
-const verb = computed(() => (props.worker === undefined ? '添加' : '更新'));
+const verb = computed(() => (props.worker === undefined ? 'Add' : 'Update'));
 </script>
 
 <template>
   <c-modal
     :show="show"
     @update:show="$emit('update:show', $event)"
-    :title="verb + 'GPT翻译器'"
+    :title="verb + 'GPT Translator'"
   >
     <n-form
       ref="formRef"
@@ -135,25 +135,25 @@ const verb = computed(() => (props.worker === undefined ? '添加' : '更新'));
       label-placement="left"
       label-width="auto"
     >
-      <n-form-item-row path="id" label="名字">
+      <n-form-item-row path="id" label="Name">
         <n-input
           v-model:value="formValue.id"
-          placeholder="给你的翻译器起个名字"
+          placeholder="Give your translator a name"
           :input-props="{ spellcheck: false }"
         />
       </n-form-item-row>
 
-      <n-form-item-row path="model" label="模型">
+      <n-form-item-row path="model" label="Model">
         <n-input
           v-model:value="formValue.model"
-          placeholder="模型名称"
+          placeholder="Model name"
           :input-props="{ spellcheck: false }"
         />
       </n-form-item-row>
-      <n-form-item-row path="endpoint" label="链接">
+      <n-form-item-row path="endpoint" label="Link">
         <n-input
           v-model:value="formValue.endpoint"
-          placeholder="兼容OpenAI的API链接，默认使用deepseek"
+          placeholder="OpenAI-compatible API link, deepseek is used by default"
           :input-props="{ spellcheck: false }"
         />
       </n-form-item-row>
@@ -161,13 +161,13 @@ const verb = computed(() => (props.worker === undefined ? '添加' : '更新'));
       <n-form-item-row path="key" label="Key">
         <n-input
           v-model:value="formValue.key"
-          placeholder="请输入Api key"
+          placeholder="Please enter Api key"
           :input-props="{ spellcheck: false }"
         />
       </n-form-item-row>
 
       <n-text depth="3" style="font-size: 12px">
-        # 链接例子：https://api.deepseek.com
+        # Link example: https://api.deepseek.com
       </n-text>
     </n-form>
 

--- a/web/src/pages/workspace/components/LocalVolumeList.vue
+++ b/web/src/pages/workspace/components/LocalVolumeList.vue
@@ -28,14 +28,14 @@ const { volumes } = storeToRefs(store);
 store.loadVolumes();
 
 const options = computed(() => {
-  return [...Object.keys(props.options ?? {}), '批量删除'].map((it) => ({
+  return [...Object.keys(props.options ?? {}), 'Batch delete'].map((it) => ({
     label: it,
     key: it,
   }));
 });
 const handleSelect = (key: string) => {
   switch (key) {
-    case '批量删除':
+    case 'Batch delete':
       openDeleteModal();
       break;
     default:
@@ -46,19 +46,19 @@ const handleSelect = (key: string) => {
 
 const downloadVolumes = async () => {
   if (sortedVolumes.value.length === 0) {
-    message.info('没有选中小说');
+    message.info('No novel selected');
     return;
   }
   const ids = sortedVolumes.value.map((it) => it.id);
   const { success, failed } = await store.downloadVolumes(ids);
-  message.info(`${success}本小说被打包，${failed}本失败`);
+  message.info(`${success} novels were packaged, ${failed} failed`);
 };
 
 const showDeleteModal = ref(false);
 
 const openDeleteModal = () => {
   if (sortedVolumes.value.length === 0) {
-    message.info('没有选中小说');
+    message.info('No novel selected');
     return;
   }
   showDeleteModal.value = true;
@@ -68,7 +68,7 @@ const deleteAllVolumes = async () => {
   const ids = sortedVolumes.value.map((it) => it.id);
   const { success, failed } = await store.deleteVolumes(ids);
   showDeleteModal.value = false;
-  message.info(`${success}本小说被删除，${failed}本失败`);
+  message.info(`${success} novels were deleted, ${failed} failed`);
 };
 
 const search = reactive({
@@ -100,14 +100,14 @@ const sortedVolumes = computed(() => {
 </script>
 
 <template>
-  <c-drawer-right title="本地小说">
+  <c-drawer-right title="Local novel">
     <template #action>
       <bookshelf-local-add-button
         :favored-id="selectedFavored"
         @done="emit('volumeAdd', $event)"
       />
       <c-button
-        label="下载"
+        label="Download"
         :icon="FileDownloadOutlined"
         @click="downloadVolumes"
       />
@@ -125,15 +125,15 @@ const sortedVolumes = computed(() => {
 
     <div style="padding: 24px 16px">
       <n-flex vertical>
-        <c-action-wrapper title="搜索">
+        <c-action-wrapper title="Search">
           <search-input
             v-model:value="search"
-            placeholder="搜索文件名"
+            placeholder="Search file name"
             style="max-width: 400px"
           />
         </c-action-wrapper>
 
-        <c-action-wrapper v-if="favoreds.local.length > 1" title="收藏">
+        <c-action-wrapper v-if="favoreds.local.length > 1" title="Favorites">
           <n-select
             v-model:value="selectedFavored"
             :options="favoredsOptions"
@@ -141,7 +141,7 @@ const sortedVolumes = computed(() => {
           />
         </c-action-wrapper>
 
-        <c-action-wrapper title="排序" align="center">
+        <c-action-wrapper title="Sort" align="center">
           <order-sort
             v-model:value="setting.localVolumeOrder"
             :options="Setting.localVolumeOrderOptions"
@@ -156,7 +156,7 @@ const sortedVolumes = computed(() => {
 
       <n-empty
         v-else-if="sortedVolumes.length === 0"
-        description="没有文件"
+        description="No files"
         style="margin-top: 20px"
       />
 
@@ -168,14 +168,13 @@ const sortedVolumes = computed(() => {
         </n-list>
       </n-scrollbar>
 
-      <c-modal title="清空所有文件" v-model:show="showDeleteModal">
+      <c-modal title="Clear all files" v-model:show="showDeleteModal">
         <n-p>
-          这将清空你的浏览器里面保存的所有EPUB/TXT文件，包括已经翻译的章节和术语表，无法恢复。
-          你确定吗？
+          This will clear all EPUB/TXT files saved in your browser, including translated chapters and glossaries, and cannot be recovered. Are you sure?
         </n-p>
 
         <template #action>
-          <c-button label="确定" type="primary" @action="deleteAllVolumes" />
+          <c-button label="Confirm" type="primary" @action="deleteAllVolumes" />
         </template>
       </c-modal>
     </div>

--- a/web/src/pages/workspace/components/LocalVolumeListKatakana.vue
+++ b/web/src/pages/workspace/components/LocalVolumeListKatakana.vue
@@ -15,7 +15,7 @@ const message = useMessage();
 const store = useBookshelfLocalStore();
 
 const deleteVolume = (volumeId: string) =>
-  doAction(store.deleteVolume(volumeId), '删除', message);
+  doAction(store.deleteVolume(volumeId), 'Delete', message);
 </script>
 
 <template>
@@ -25,13 +25,13 @@ const deleteVolume = (volumeId: string) =>
         <n-text>{{ volume.id }}</n-text>
 
         <n-text depth="3">
-          <n-time :time="volume.createAt" type="relative" /> / 总计
+          <n-time :time="volume.createAt" type="relative" /> / Total
           {{ volume.toc.length }}
         </n-text>
 
         <n-flex :size="8">
           <c-button
-            label="载入"
+            label="Load"
             size="tiny"
             secondary
             @action="$emit('volumeLoaded', volume.id)"
@@ -47,7 +47,7 @@ const deleteVolume = (volumeId: string) =>
           <div style="flex: 1" />
 
           <c-button-confirm
-            :hint="`真的要删除《${volume.id}》吗？`"
+            :hint="`Are you sure you want to delete '${volume.id}'?`"
             :icon="DeleteOutlineOutlined"
             size="tiny"
             secondary

--- a/web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue
+++ b/web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue
@@ -25,7 +25,7 @@ const { setting } = Locator.settingRepository();
 const store = useBookshelfLocalStore();
 
 const deleteVolume = (volumeId: string) =>
-  doAction(store.deleteVolume(volumeId), '删除', message);
+  doAction(store.deleteVolume(volumeId), 'Delete', message);
 
 const calculateFinished = (volume: LocalVolumeMetadata) =>
   volume.toc.filter((it) => {
@@ -58,7 +58,7 @@ const queueAllVolumes = (volumes: LocalVolumeMetadata[]) => {
     type: props.type,
     shouldTop: shouldTopJob.value ?? false,
   });
-  message.info(`${success}本小说已排队，${failed}本失败`);
+  message.info(`${success} novels have been queued, ${failed} failed`);
 };
 
 const shouldTopJob = useKeyModifier('Control');
@@ -76,9 +76,9 @@ const queueVolume = (volumeId: string, total: number = 65536) => {
     total: total,
   });
   if (success) {
-    message.success('排队成功');
+    message.success('Queue successful');
   } else {
-    message.error('排队失败：翻译任务已经存在');
+    message.error('Queue failed: translation task already exists');
   }
 };
 
@@ -95,15 +95,15 @@ const downloadVolume = async (volumeId: string) => {
     });
     downloadFile(filename, blob);
   } catch (error) {
-    message.error(`文件生成错误：${error}`);
+    message.error(`File generation error: ${error}`);
   }
 };
 
 const progressFilter = ref<'all' | 'finished' | 'unfinished'>('all');
 const progressFilterOptions = [
-  { value: 'all', label: '全部' },
-  { value: 'finished', label: '已完成' },
-  { value: 'unfinished', label: '未完成' },
+  { value: 'all', label: 'All' },
+  { value: 'finished', label: 'Finished' },
+  { value: 'unfinished', label: 'Unfinished' },
 ];
 const progressFilterFunc = computed(() => {
   if (progressFilter.value === 'finished') {
@@ -123,7 +123,7 @@ const progressFilterFunc = computed(() => {
 <template>
   <local-volume-list
     :filter="progressFilterFunc"
-    :options="{ 全部排队: queueAllVolumes }"
+    :options="{ 'Queue all': queueAllVolumes }"
     @volume-add="queueVolume($event.name)"
   >
     <template #extra>
@@ -133,7 +133,7 @@ const progressFilterFunc = computed(() => {
         :glossary="{}"
       />
       <n-divider style="margin: 12px 0" />
-      <c-action-wrapper title="状态">
+      <c-action-wrapper title="Status">
         <c-radio-group
           v-model:value="progressFilter"
           :options="progressFilterOptions"
@@ -141,7 +141,7 @@ const progressFilterFunc = computed(() => {
         />
       </c-action-wrapper>
 
-      <c-action-wrapper title="语言">
+      <c-action-wrapper title="Language">
         <c-radio-group
           v-model:value="setting.downloadFormat.mode"
           :options="Setting.downloadModeOptions"
@@ -156,14 +156,14 @@ const progressFilterFunc = computed(() => {
 
         <n-text depth="3">
           <n-time :time="volume.createAt" type="relative" />
-          / 总计 {{ volume.toc.length }} / 完成
-          {{ calculateFinished(volume) }} / 过期
+          / Total {{ volume.toc.length }} / Finished
+          {{ calculateFinished(volume) }} / Expired
           {{ calculateExpired(volume) }}
         </n-text>
 
         <n-flex :size="8">
           <c-button
-            label="排队"
+            label="Queue"
             size="tiny"
             secondary
             @action="queueVolume(volume.id, volume.toc.length)"
@@ -174,11 +174,11 @@ const progressFilterFunc = computed(() => {
             :to="`/workspace/reader/${encodeURIComponent(volume.id)}/0`"
             target="_blank"
           >
-            <c-button label="阅读" size="tiny" secondary />
+            <c-button label="Read" size="tiny" secondary />
           </router-link>
 
           <c-button
-            label="下载"
+            label="Download"
             size="tiny"
             secondary
             @action="downloadVolume(volume.id)"
@@ -194,7 +194,7 @@ const progressFilterFunc = computed(() => {
           <div style="flex: 1" />
 
           <c-button-confirm
-            :hint="`真的要删除《${volume.id}》吗？`"
+            :hint="`Are you sure you want to delete '${volume.id}'?`"
             :icon="DeleteOutlineOutlined"
             size="tiny"
             secondary

--- a/web/src/pages/workspace/components/SakuraWorkerModal.vue
+++ b/web/src/pages/workspace/components/SakuraWorkerModal.vue
@@ -35,7 +35,7 @@ const formRules: FormRules = {
   id: [
     {
       validator: (rule: FormItemRule, value: string) => value.trim().length > 0,
-      message: '名字不能为空',
+      message: 'Name cannot be empty',
       trigger: 'input',
     },
     {
@@ -43,14 +43,14 @@ const formRules: FormRules = {
         workspaceRef.value.workers
           .filter(({ id }) => id !== props.worker?.id)
           .find(({ id }) => id === value) === undefined,
-      message: '名字不能重复',
+      message: 'Name cannot be repeated',
       trigger: 'input',
     },
   ],
   endpoint: [
     {
       validator: (rule: FormItemRule, value: string) => value.trim().length > 0,
-      message: '链接不能为空',
+      message: 'Link cannot be empty',
       trigger: 'input',
     },
     {
@@ -62,7 +62,7 @@ const formRules: FormRules = {
           return false;
         }
       },
-      message: '链接不合法',
+      message: 'Link is not valid',
       trigger: 'input',
     },
   ],
@@ -92,14 +92,14 @@ const submit = async () => {
   }
 };
 
-const verb = computed(() => (props.worker === undefined ? '添加' : '更新'));
+const verb = computed(() => (props.worker === undefined ? 'Add' : 'Update'));
 </script>
 
 <template>
   <c-modal
     :show="show"
     @update:show="$emit('update:show', $event)"
-    :title="verb + 'Sakura翻译器'"
+    :title="verb + 'Sakura Translator'"
   >
     <n-form
       ref="formRef"
@@ -108,22 +108,22 @@ const verb = computed(() => (props.worker === undefined ? '添加' : '更新'));
       label-placement="left"
       label-width="auto"
     >
-      <n-form-item-row path="id" label="名字">
+      <n-form-item-row path="id" label="Name">
         <n-input
           v-model:value="formValue.id"
-          placeholder="给你的翻译器起个名字"
+          placeholder="Give your translator a name"
           :input-props="{ spellcheck: false }"
         />
       </n-form-item-row>
-      <n-form-item-row path="endpoint" label="链接">
+      <n-form-item-row path="endpoint" label="Link">
         <n-input
           v-model:value="formValue.endpoint"
-          placeholder="翻译器的链接"
+          placeholder="Translator link"
           :input-props="{ spellcheck: false }"
         />
       </n-form-item-row>
 
-      <n-form-item-row path="segLength" label="分段长度">
+      <n-form-item-row path="segLength" label="Segment length">
         <n-input-number
           v-model:value="formValue.segLength"
           :show-button="false"
@@ -131,7 +131,7 @@ const verb = computed(() => (props.worker === undefined ? '添加' : '更新'));
         />
       </n-form-item-row>
 
-      <n-form-item-row path="prevSegLength" label="前文长度">
+      <n-form-item-row path="prevSegLength" label="Previous text length">
         <n-input-number
           v-model:value="formValue.prevSegLength"
           :show-button="false"
@@ -140,13 +140,13 @@ const verb = computed(() => (props.worker === undefined ? '添加' : '更新'));
       </n-form-item-row>
 
       <n-text type="error" style="font-size: 12px">
-        # 前文长度是临时功能，非默认500无法上传
+        # Previous text length is a temporary function, cannot upload if not the default 500
       </n-text>
       <br />
       <n-text depth="3" style="font-size: 12px">
-        # 分段长度还在测试中，非默认500无法上传
+        # Segment length is still under testing, cannot upload if not the default 500
         <br />
-        # 链接例子：http://127.0.0.1:8080
+        # Link example: http://127.0.0.1:8080
       </n-text>
     </n-form>
 

--- a/web/src/pages/workspace/components/ToolboxItemFixOcr.vue
+++ b/web/src/pages/workspace/components/ToolboxItemFixOcr.vue
@@ -55,15 +55,15 @@ const fixOcr = () =>
   Toolbox.modifyFiles(
     props.files.filter((file) => file.type === 'txt'),
     fixOcrForTxt,
-    (e) => message.error(`发生错误：${e}`),
+    (e) => message.error(`Error: ${e}`),
   );
 </script>
 
 <template>
   <n-flex vertical>
-    OCR输出的文本通常存在额外的换行符，导致翻译器错误。当前修复方法是检测每一行的结尾是否是字符（汉字/日文假名/韩文字符/英文字母/全角半角逗号），如果是的话则删除行尾的换行符。
+    Text output by OCR often has extra newlines, causing translator errors. The current fix is to detect if the end of each line is a character (Chinese/Japanese/Korean/English/full-width or half-width comma), and if so, remove the newline at the end of the line.
     <n-flex>
-      <c-button label="修复" @action="fixOcr" />
+      <c-button label="Fix" @action="fixOcr" />
     </n-flex>
   </n-flex>
 </template>

--- a/web/src/pages/workspace/components/ToolboxItemGlossary.vue
+++ b/web/src/pages/workspace/components/ToolboxItemGlossary.vue
@@ -89,7 +89,7 @@ const copyTranslationJson = async () => {
   );
   const jsonString = Glossary.toText(obj);
   navigator.clipboard.writeText(jsonString);
-  message.info('已经将翻译结果复制到剪切板');
+  message.info('The translation result has been copied to the clipboard');
 };
 
 const showSakuraSelectModal = ref(false);
@@ -104,7 +104,7 @@ const translateKatakanas = async (id: 'baidu' | 'youdao' | 'sakura') => {
       (it) => it.id === selectedSakuraWorkerId.value,
     );
     if (worker === undefined) {
-      message.error('未选择Sakura翻译器');
+      message.error('Sakura translator not selected');
       return;
     }
     config = {
@@ -126,7 +126,7 @@ const translateKatakanas = async (id: 'baidu' | 'youdao' | 'sakura') => {
     });
     katakanaTranslations.value = jpToZh;
   } catch (e: unknown) {
-    message.error(`翻译器错误：${e}`);
+    message.error(`Translator error: ${e}`);
   }
 };
 </script>
@@ -134,15 +134,15 @@ const translateKatakanas = async (id: 'baidu' | 'youdao' | 'sakura') => {
 <template>
   <n-flex vertical size="large">
     <bulletin>
-      <n-p>术语表辅助制作工具正在开发中，当前方案分为识别和翻译两步。</n-p>
+      <n-p>The glossary-making tool is under development. The current plan is divided into two steps: recognition and translation.</n-p>
       <n-ul>
-        <n-li>识别阶段：根据片假名词汇出现频率判断可能是术语的词汇。</n-li>
-        <n-li>翻译阶段：直接翻译日语词汇。</n-li>
+        <n-li>Recognition stage: Identify possible terminology based on the frequency of katakana vocabulary.</n-li>
+        <n-li>Translation stage: Directly translate Japanese vocabulary.</n-li>
       </n-ul>
-      <n-p><b>注意，这是辅助制作，不是全自动生成，使用前务必检查结果。</b></n-p>
+      <n-p><b>Note that this is an auxiliary production, not a fully automatic generation. Be sure to check the results before use.</b></n-p>
     </bulletin>
 
-    <c-action-wrapper title="次数下限">
+    <c-action-wrapper title="Minimum number of times">
       <n-input-number
         v-model:value="katakanaThredhold"
         clearable
@@ -152,21 +152,21 @@ const translateKatakanas = async (id: 'baidu' | 'youdao' | 'sakura') => {
       />
     </c-action-wrapper>
 
-    <c-action-wrapper title="操作">
+    <c-action-wrapper title="Operation">
       <n-flex vertical>
         <n-button-group size="small">
           <c-button
-            label="复制术语表"
+            label="Copy glossary"
             :round="false"
             @action="copyTranslationJson()"
           />
           <c-button
-            label="百度翻译"
+            label="Baidu Translate"
             :round="false"
             @action="translateKatakanas('baidu')"
           />
           <c-button
-            label="有道翻译"
+            label="Youdao Translate"
             :round="false"
             @action="translateKatakanas('youdao')"
           />
@@ -174,12 +174,12 @@ const translateKatakanas = async (id: 'baidu' | 'youdao' | 'sakura') => {
 
         <n-button-group size="small">
           <c-button
-            :label="`Sakura翻译-${selectedSakuraWorkerId ?? '未选中'}`"
+            :label="`Sakura Translate-${selectedSakuraWorkerId ?? 'Not selected'}`"
             :round="false"
             @action="translateKatakanas('sakura')"
           />
           <c-button
-            label="选择翻译器"
+            label="Select translator"
             :round="false"
             @action="showSakuraSelectModal = true"
           />
@@ -188,7 +188,7 @@ const translateKatakanas = async (id: 'baidu' | 'youdao' | 'sakura') => {
         <n-flex align="center" :wrap="false">
           <c-button
             :disabled="katakanaDeleted.length === 0"
-            label="撤销删除"
+            label="Undo delete"
             :round="false"
             size="small"
             @action="undoDeleteKatakana"
@@ -218,7 +218,7 @@ const translateKatakanas = async (id: 'baidu' | 'youdao' | 'sakura') => {
         <tr v-for="[word, number] in katakanas" :key="word">
           <td>
             <c-icon-button
-              tooltip="移除"
+              tooltip="Remove"
               :icon="DeleteOutlineOutlined"
               text
               size="small"
@@ -233,7 +233,7 @@ const translateKatakanas = async (id: 'baidu' | 'youdao' | 'sakura') => {
             <n-input
               v-model:value="katakanaTranslations[word]"
               size="tiny"
-              placeholder="请输入中文翻译"
+              placeholder="Please enter Chinese translation"
               :theme-overrides="{
                 border: '0',
                 color: 'transprent',
@@ -245,7 +245,7 @@ const translateKatakanas = async (id: 'baidu' | 'youdao' | 'sakura') => {
     </n-scrollbar>
   </n-flex>
 
-  <c-modal title="选择Sakura翻译器" v-model:show="showSakuraSelectModal">
+  <c-modal title="Select Sakura translator" v-model:show="showSakuraSelectModal">
     <n-radio-group v-model:value="selectedSakuraWorkerId">
       <n-flex vertical>
         <n-radio

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -100,7 +100,7 @@ export default defineConfig(({ command, mode }) => {
     },
     plugins: [
       vue(),
-      // imagemin({}),
+      imagemin({}),
       createHtmlPlugin({
         minify: { minifyJS: true },
       }),


### PR DESCRIPTION
Re-enabled `unplugin-imagemin` in `vite.config.ts` to restore image compression during the build process.

Also fixed a large number of hardcoded Chinese strings throughout the codebase, replacing them with English translations. A log of these changes is available in `translation_fixes.log`.